### PR TITLE
(MAINT) Add rubocop style enforcer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,478 @@
+AllCops:
+  Exclude:
+    # Ignore HTML related things
+    - '**/*.erb'
+    # Ignore vendored gems
+    - 'vendor/**/*'
+
+Lint/ConditionPosition:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/HandleExceptions:
+  Enabled: true
+
+Lint/LiteralInCondition:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Style/SpaceBeforeComment:
+  Enabled: true
+
+# DISABLED - not useful
+Style/HashSyntax:
+  Enabled: false
+
+# USES: as shortcut for non nil&valid checking a = x() and a.empty?
+# DISABLED - not useful
+Style/AndOr:
+  Enabled: false
+
+# DISABLED - not useful
+Style/RedundantSelf:
+  Enabled: false
+
+# DISABLED - not useful
+Metrics/MethodLength:
+  Enabled: false
+
+# DISABLED - not useful
+Style/WhileUntilModifier:
+  Enabled: false
+
+# DISABLED - the offender is just haskell envy
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+# DISABLED
+Lint/Eval:
+  Enabled: false
+
+# DISABLED
+Lint/BlockAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/DefEndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/EndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/DeprecatedClassMethods:
+  Enabled: false
+
+# DISABLED
+Lint/Loop:
+  Enabled: false
+
+# DISABLED
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/StringConversionInInterpolation:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAccessModifier:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Style/AccessModifierIndentation:
+  Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Style/AlignArray:
+  Enabled: false
+
+Style/AlignHash:
+  Enabled: false
+
+Style/AlignParameters:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/CaseIndentation:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/WhenThen:
+  Enabled: false
+
+# DISABLED - not useful
+Style/WordArray:
+  Enabled: false
+
+Style/UnneededPercentQ:
+  Enabled: false
+
+Style/Tab:
+  Enabled: false
+
+Style/SpaceBeforeSemicolon:
+  Enabled: false
+
+Style/TrailingBlankLines:
+  Enabled: false
+
+Style/SpaceInsideBlockBraces:
+  Enabled: false
+
+Style/SpaceInsideBrackets:
+  Enabled: false
+
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Style/SpaceInsideParens:
+  Enabled: false
+
+Style/LeadingCommentSpace:
+  Enabled: false
+
+Style/SingleSpaceBeforeFirstArg:
+  Enabled: false
+
+Style/SpaceAfterColon:
+  Enabled: false
+
+Style/SpaceAfterComma:
+  Enabled: false
+
+Style/SpaceAfterControlKeyword:
+  Enabled: false
+
+Style/SpaceAfterMethodName:
+  Enabled: false
+
+Style/SpaceAfterNot:
+  Enabled: false
+
+Style/SpaceAfterSemicolon:
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
+
+Style/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Style/SpaceBeforeComma:
+  Enabled: false
+
+Style/CollectionMethods:
+  Enabled: false
+
+Style/CommentIndentation:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Style/ConstantName:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DefWithParentheses:
+  Enabled: false
+
+Style/DeprecatedHashMethods:
+  Enabled: false
+
+Style/DotPosition:
+  Enabled: false
+
+# DISABLED - used for converting to bool
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/EmptyLineBetweenDefs:
+  Enabled: false
+
+Style/IndentArray:
+  Enabled: false
+
+Style/IndentHash:
+  Enabled: false
+
+Style/IndentationConsistency:
+  Enabled: false
+
+Style/IndentationWidth:
+  Enabled: false
+
+Style/EmptyLines:
+  Enabled: false
+
+Style/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Style/EmptyLiteral:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/MethodCallParentheses:
+  Enabled: false
+
+Style/MethodDefParentheses:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Style/TrailingWhitespace:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/TrailingComma:
+  Enabled: false
+
+Style/GlobalVars:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MultilineIfThen:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/NegatedWhile:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SingleLineMethods:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false
+
+Style/VariableInterpolation:
+  Enabled: false
+
+Style/VariableName:
+  Enabled: false
+
+Style/WhileUntilDo:
+  Enabled: false
+
+Style/EvenOdd:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/For:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/MethodName:
+  Enabled: false
+
+Style/MultilineTernaryOperator:
+  Enabled: false
+
+Style/NestedTernaryOperator:
+  Enabled: false
+
+Style/NilComparison:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/NonNilCheck:
+  Enabled: false
+
+Style/Not:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/OneLineConditional:
+  Enabled: false
+
+Style/OpMethod:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/PredicateName:
+  Enabled: false
+
+Style/RedundantException:
+  Enabled: false
+
+Style/SelfAssignment:
+  Enabled: false
+
+Style/Proc:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/RedundantBegin:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: false
+
+Lint/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Lint/Debugger:
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'rubocop', require: false
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -4,20 +4,23 @@ require 'bundler/setup'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
+require 'rubocop/rake_task'
 
 # This gem isn't always present, for instance
 # on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 # This gem isn't always present, for instance
-# on Travis with --without integration
+# on Travis with --without acceptance
 begin
 require 'master_manipulator'
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
+
+RuboCop::RakeTask.new
 
 exclude_paths = [
   "pkg/**/*",
@@ -54,5 +57,6 @@ task :test => [
   :metadata,
   :syntax,
   :lint,
+  :rubocop,
   :spec,
 ]

--- a/lib/puppet/provider/azure_vm/azure_sdk.rb
+++ b/lib/puppet/provider/azure_vm/azure_sdk.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_sdk, :parent => PuppetX::Puppetlabs:
 
   def self.prefetch(resources)
     instances.each do |prov|
-      if resource = resources[prov.name]
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
         resource.provider = prov
       end
     end
@@ -60,5 +60,4 @@ Puppet::Type.type(:azure_vm).provide(:azure_sdk, :parent => PuppetX::Puppetlabs:
     delete_vm(@property_hash[:object])
     @property_hash[:ensure] = :absent
   end
-
 end

--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -2,48 +2,46 @@ require_relative '../../puppet_x/puppetlabs/azure/property/read_only'
 require_relative '../../puppet_x/puppetlabs/azure/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/azure/property/string'
 
-=begin
-azure_vm { 'sample':
-  user                  => 'azureuser',
-  image                 => '5112500ae3b842c8b9c604889f8753c3__OpenLogic-CentOS-63APR20130415',
-  password              => 'Password',
-  location              => 'West US'
-  storage_account_name  => 'storage_suse',
-  winrm_transport       => ['https','http'],
-  winrm_https_port      => 5999,
-  winrm_http_port       => 6999,
-  cloud_service_name    => 'cloud_service_name',
-  deployment_name       =>'vm_name',
-  tcp_endpoints         => '80,3389:3390',
-  private_key_file      => './private_key.key', # required for ssh
-  ssh_port              => 2222,
-  vm_size               => 'Small',
-  affinity_group_name   => 'affinity1',
-  virtual_network_name  => 'xplattestvnet',
-  subnet_name           => 'subnet1',
-  availability_set_name => 'availabiltyset1',
-  reserved_ip_name      => 'reservedipname'
-  endpoints             => [{
-    :name        => 'ep-1',
-    :public_port => 996,
-    :local_port  => 998,
-    :protocol    => 'TCP',
-  },{
-    :name               => 'ep-2',
-    :public_port        => 997,
-    :local_port         => 997,
-    :protocol           => 'TCP',
-    :load_balancer_name => 'lb-ep2',
-    :load_balancer      => {:protocol => 'http', :path => 'hello'},
-  }],
-   disks                => [{
-    'label'  => 'disk-label',
-    'size'   => 100, #In GB
-    'import' => false,
-    'name'   => 'Disk name', #Required when import is true
-  }],
-}
-=end
+# azure_vm { 'sample':
+#   user                  => 'azureuser',
+#   image                 => '5112500ae3b842c8b9c604889f8753c3__OpenLogic-CentOS-63APR20130415',
+#   password              => 'Password',
+#   location              => 'West US'
+#   storage_account_name  => 'storage_suse',
+#   winrm_transport       => ['https','http'],
+#   winrm_https_port      => 5999,
+#   winrm_http_port       => 6999,
+#   cloud_service_name    => 'cloud_service_name',
+#   deployment_name       =>'vm_name',
+#   tcp_endpoints         => '80,3389:3390',
+#   private_key_file      => './private_key.key', # required for ssh
+#   ssh_port              => 2222,
+#   vm_size               => 'Small',
+#   affinity_group_name   => 'affinity1',
+#   virtual_network_name  => 'xplattestvnet',
+#   subnet_name           => 'subnet1',
+#   availability_set_name => 'availabiltyset1',
+#   reserved_ip_name      => 'reservedipname'
+#   endpoints             => [{
+#     :name        => 'ep-1',
+#     :public_port => 996,
+#     :local_port  => 998,
+#     :protocol    => 'TCP',
+#   },{
+#     :name               => 'ep-2',
+#     :public_port        => 997,
+#     :local_port         => 997,
+#     :protocol           => 'TCP',
+#     :load_balancer_name => 'lb-ep2',
+#     :load_balancer      => {:protocol => 'http', :path => 'hello'},
+#   }],
+#    disks                => [{
+#     'label'  => 'disk-label',
+#     'size'   => 100, #In GB
+#     'import' => false,
+#     'name'   => 'Disk name', #Required when import is true
+#   }],
+# }
 
 Puppet::Type.newtype(:azure_vm) do
   @doc = 'Type representing a virtual machine in Microsoft Azure.'
@@ -202,5 +200,4 @@ Puppet::Type.newtype(:azure_vm) do
     newproperty(property, :parent => PuppetX::PuppetLabs::Azure::Property::ReadOnly) do
     end
   end
-
 end

--- a/lib/puppet_x/puppetlabs/azure/provider.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider.rb
@@ -50,7 +50,6 @@ module PuppetX
           ensure
             $stdout = real_stdout
           end
-
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,9 @@ RSpec::Matchers.define :require_string_for do |property|
   match do |type_class|
     config = {name: 'name'}
     config[property] = 2
-    expect {
+    expect do
       type_class.new(config)
-    }.to raise_error(Puppet::Error, /#{property} should be a String/)
+    end.to raise_error(Puppet::Error, /#{property} should be a String/)
   end
   failure_message do |type_class|
     "#{type_class} should require #{property} to be a String"
@@ -22,9 +22,9 @@ RSpec::Matchers.define :require_hash_for do |property|
   match do |type_class|
     config = {name: 'name'}
     config[property] = 2
-    expect {
+    expect do
       type_class.new(config)
-    }.to raise_error(Puppet::Error, /#{property} should be a Hash/)
+    end.to raise_error(Puppet::Error, /#{property} should be a Hash/)
   end
   failure_message do |type_class|
     "#{type_class} should require #{property} to be a Hash"
@@ -35,9 +35,9 @@ RSpec::Matchers.define :require_integer_for do |property|
   match do |type_class|
     config = {name: 'name'}
     config[property] = 'string'
-    expect {
+    expect do
       type_class.new(config)
-    }.to raise_error(Puppet::Error, /#{property} should be an Integer/)
+    end.to raise_error(Puppet::Error, /#{property} should be an Integer/)
   end
   failure_message do |type_class|
     "#{type_class} should require #{property} to be a Integer"
@@ -48,9 +48,9 @@ RSpec::Matchers.define :be_read_only do |property|
   match do |type_class|
     config = {name: 'name'}
     config[property] = 'invalid'
-    expect {
+    expect do
       type_class.new(config)
-    }.to raise_error(Puppet::Error, /#{property} is read-only/)
+    end.to raise_error(Puppet::Error, /#{property} is read-only/)
   end
   failure_message do |type_class|
     "#{type_class} should require #{property} to be read-only"

--- a/spec/unit/azure_config_spec.rb
+++ b/spec/unit/azure_config_spec.rb
@@ -85,7 +85,6 @@ describe PuppetX::Puppetlabs::Azure::Config do
     it 'should return the management_certificate from the config file' do
       expect(config.management_certificate).to eq(@config[:management_certificate])
     end
-
   end
 
   context 'with no environment variables and a valid config file present' do
@@ -112,7 +111,6 @@ describe PuppetX::Puppetlabs::Azure::Config do
     it 'should return the management_certificate from the config file' do
       expect(config.management_certificate).to eq(@config[:management_certificate])
     end
-
   end
 
   context 'with no environment variables or config file' do
@@ -121,9 +119,9 @@ describe PuppetX::Puppetlabs::Azure::Config do
     end
 
     it 'should raise a suitable error' do
-      expect {
+      expect do
         PuppetX::Puppetlabs::Azure::Config.new
-      }.to raise_error(Puppet::Error, /You must provide credentials in either environment variables or a config file/)
+      end.to raise_error(Puppet::Error, /You must provide credentials in either environment variables or a config file/)
     end
   end
 
@@ -134,9 +132,9 @@ describe PuppetX::Puppetlabs::Azure::Config do
     end
 
     it 'should raise an error about the missing variables' do
-      expect {
+      expect do
         PuppetX::Puppetlabs::Azure::Config.new
-      }.to raise_error(Puppet::Error, /To use this module you must provide the following settings: management_certificate/)
+      end.to raise_error(Puppet::Error, /To use this module you must provide the following settings: management_certificate/)
     end
   end
 
@@ -155,9 +153,9 @@ describe PuppetX::Puppetlabs::Azure::Config do
     end
 
     it 'should raise an error about the missing variables' do
-      expect {
+      expect do
         PuppetX::Puppetlabs::Azure::Config.new(@path)
-      }.to raise_error(Puppet::Error, /To use this module you must provide the following settings: management_certificate/)
+      end.to raise_error(Puppet::Error, /To use this module you must provide the following settings: management_certificate/)
     end
   end
 
@@ -177,10 +175,9 @@ describe PuppetX::Puppetlabs::Azure::Config do
     end
 
     it 'should raise an error about the invalid config file' do
-      expect {
+      expect do
         PuppetX::Puppetlabs::Azure::Config.new(config_file_path)
-      }.to raise_error(Puppet::Error, /Your configuration file at .+ is invalid/)
+      end.to raise_error(Puppet::Error, /Your configuration file at .+ is invalid/)
     end
   end
-
 end

--- a/spec/unit/provider/azure_vm/azure_sdk_spec.rb
+++ b/spec/unit/provider/azure_vm/azure_sdk_spec.rb
@@ -3,12 +3,11 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:azure_vm).provider(:azure_sdk)
 
 describe provider_class do
-
-  let(:resource) {
+  let(:resource) do
     Puppet::Type.type(:azure_vm).new(
       name: 'name',
     )
-  }
+  end
 
   let(:provider) { resource.provider }
 
@@ -32,5 +31,4 @@ describe provider_class do
     expect(provider_class).to receive(:instances).and_return([])
     provider_class.prefetch({})
   end
-
 end

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 type_class = Puppet::Type.type(:azure_vm)
 
 describe type_class do
-
-
-
   let :params do
     [
       :name,
@@ -56,9 +53,9 @@ describe type_class do
   end
 
   it 'should require a name' do
-    expect {
+    expect do
       type_class.new({})
-    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+    end.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
   [
@@ -93,11 +90,11 @@ describe type_class do
     end
 
     it "should require #{property} to be greater than 0" do
-      expect {
+      expect do
         config = {name: 'sample'}
         config[property] = 0
         type_class.new(config)
-      }.to raise_error(Puppet::Error, /#{property} should be greater than 0/)
+      end.to raise_error(Puppet::Error, /#{property} should be greater than 0/)
     end
   end
 
@@ -137,44 +134,43 @@ describe type_class do
 
     [:label, :size].each do |key|
       it "should require disk to have a #{key} key" do
-        expect {
+        expect do
           config[:disks].delete(key)
           type_class.new(config)
-        }.to raise_error(Puppet::Error, /for disks you are missing the following keys: #{key}/)
+        end.to raise_error(Puppet::Error, /for disks you are missing the following keys: #{key}/)
       end
     end
 
     it "should require disk size to be an integer" do
-      expect {
+      expect do
         config[:disks][:size] = 'invalid'
         type_class.new(config)
-      }.to raise_error(Puppet::Error, /size for disks should be an Integer/)
+      end.to raise_error(Puppet::Error, /size for disks should be an Integer/)
     end
 
     it 'should require disk import to be true or false if set' do
-      expect {
+      expect do
         config[:disks][:import] = 'invalid'
         type_class.new(config)
-      }.to raise_error(Puppet::Error, /import for disks must be true or false/)
+      end.to raise_error(Puppet::Error, /import for disks must be true or false/)
     end
 
     [true, false].each do |bool|
       it "should allow import to be #{bool}" do
-        expect {
+        expect do
           config[:disks][:import] = bool
           type_class.new(config)
-        }.to_not raise_error
+        end.to_not raise_error
       end
     end
 
     it 'when import is true should require name to be specified for disk' do
-      expect {
+      expect do
         config[:disks][:import] = true
         config[:disks].delete(:name)
         type_class.new(config)
-      }.to raise_error(Puppet::Error, /if import is true a name must be provided for disks/)
+      end.to raise_error(Puppet::Error, /if import is true a name must be provided for disks/)
     end
-
   end
 
   context 'with an endpoint specified' do
@@ -197,22 +193,20 @@ describe type_class do
 
     [:name, :public_port, :local_port, :protocol].each do |key|
       it "should require endpoint to have a #{key} key" do
-        expect {
+        expect do
           config[:endpoints].delete(key)
           type_class.new(config)
-        }.to raise_error(Puppet::Error, /for endpoints you are missing the following keys: #{key}/)
+        end.to raise_error(Puppet::Error, /for endpoints you are missing the following keys: #{key}/)
       end
     end
 
     [:local_port, :public_port].each do |port|
       it "should require endpoint #{port} to be an integer" do
-        expect {
+        expect do
           config[:endpoints][port] = 'invalid'
           type_class.new(config)
-        }.to raise_error(Puppet::Error, /#{port} for endpoints should be an Integer/)
+        end.to raise_error(Puppet::Error, /#{port} for endpoints should be an Integer/)
       end
     end
-
   end
-
 end


### PR DESCRIPTION
The rubocop config file is from work done by the Puppet team. I reason
it's a good starting point although we can enable more rules if we
choose to do so.

This commit also fixes up the violations picked up using that ruleset.
