### PR TITLE
(WIP)(CLOUD-417) Acceptance test extension to run in vagrant or vmpooler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 
 group :acceptance do
   gem 'mustache'
-  gem "beaker-puppet_install_helper", :require => false
+  gem 'beaker-puppet_install_helper', :require => false
   gem 'beaker', '~> 2.0'
   gem 'master_manipulator', '~> 1.0'
   gem 'beaker-rspec'

--- a/Rakefile0.undefined
+++ b/Rakefile0.undefined
@@ -1,0 +1,55 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+# This gem isn't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+# This gem isn't always present, for instance
+# on Travis with --without integration
+begin
+require 'master_manipulator'
+rescue LoadError
+end
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+
+Rake::Task[:lint].clear
+
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.disable_80chars
+PuppetLint.configuration.disable_class_inherits_from_params_class
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = exclude_paths
+end
+
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+# Use our own metadata task so we can ignore the non-SPDX PE licence
+Rake::Task[:metadata].clear
+desc "Check metadata is valid JSON"
+task :metadata do
+  sh "bundle exec metadata-json-lint metadata.json --no-strict-license"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :metadata,
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -1,0 +1,13 @@
+require 'rake/task_arguments'
+require 'rake/tasklib'
+require 'rake'
+
+task :default => [:test]
+
+task :test do
+  puts "GH:: in :test"
+end
+
+task :rspec do
+  puts "GH:: HA this is the rspec task"
+end

--- a/spec/acceptance/virtual_machine_spec.rb
+++ b/spec/acceptance/virtual_machine_spec.rb
@@ -1,16 +1,35 @@
 require 'spec_helper_acceptance'
 
 describe 'azure_vm' do
-  def get_virtual_machine(name)
+  def test_get_vm(name)
     azureHelper = AzureHelper.new
     vm = azureHelper.get_virtual_machine(name)
     expect(vm).not_to be_nil
+    expect(vm.first.name).to eq(name)
     vm.first
   end
 
-  describe 'should create a new instance' do
-    it "Initial stub test" do
-      expect(get_virtual_machine('fauximage')).not_to eq (nil)
+  def test_get_image(name)
+    azureHelper = AzureHelper.new
+    image = azureHelper.get_image(name)
+    expect(image).not_to be_nil
+    expect(image.first.name).to eq(name)
+    image.first
+  end
+
+  def test_get_images()
+    azureHelper = AzureHelper.new
+    images = azureHelper.get_all_images()
+    expect(images).not_to be_nil
+    expect(images.size).not_to eq(0)
+    images
+  end
+
+  describe 'find a specfic image in azure' do
+    it 'find an image in azure' do
+      images = test_get_images()
+      image = test_get_image(images.first.name)
+      expect(images.first.name).to eq(image.name)
     end
   end
 end

--- a/spec/hosts/pooler/centos6.cfg
+++ b/spec/hosts/pooler/centos6.cfg
@@ -1,0 +1,25 @@
+HOSTS:
+  centos-6-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+  centos-6-x86_64-agent:
+    roles:
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com
+  pe_dir: http://pe-releases.puppetlabs.lan/3.8.1/

--- a/spec/hosts/pooler/centos7.cfg
+++ b/spec/hosts/pooler/centos7.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  centos-7-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+  centos-7-x86_64-agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/hosts/pooler/rhel7.cfg
+++ b/spec/hosts/pooler/rhel7.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/hosts/pooler/rhel7m-scientific7a.cfg
+++ b/spec/hosts/pooler/rhel7m-scientific7a.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/scientific-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/hosts/pooler/ubuntum-debian7a.cfg
+++ b/spec/hosts/pooler/ubuntum-debian7a.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: debian-7-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/debian-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/hosts/vagrant/centos7.cfg
+++ b/spec/hosts/vagrant/centos7.cfg
@@ -1,0 +1,23 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/hosts/vagrant/ubuntu1404.cfg
+++ b/spec/hosts/vagrant/ubuntu1404.cfg
@@ -1,0 +1,23 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+  agent:
+    roles:
+      - agent
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/pre-suite/0_dep.rb
+++ b/spec/pre-suite/0_dep.rb
@@ -1,0 +1,5 @@
+test_name "Install nokogiri dependencies for RedHat"
+confine :to, :platform => ['el-6-x86_64', 'el-7-x86_64']
+agents.each do |agent|
+    on(agent, 'yum install zlib-devel patch -y')
+end

--- a/spec/pre-suite/1_pe_install.rb
+++ b/spec/pre-suite/1_pe_install.rb
@@ -1,0 +1,27 @@
+require 'master_manipulator'
+test_name 'Install Puppet Enterprise'
+
+# Cloud Provisioner is rarely installed by customers but Beaker defaults
+# to installing it, which masks issues due to that package installing
+# nokogiri
+@hosts.each do |host|
+  host[:custom_answers] ||= {}
+  host[:custom_answers][:q_puppet_cloud_install] = 'n'
+end
+
+# Init
+options[:version] = ENV['PUPPET_AGENT_VERSION'] || '1.2.0'
+options[:sha] = ENV['PUPPET_AGENT_VERSION'] || '1.2.0'
+
+step 'Install PE'
+install_pe
+
+step 'Disable Node Classifier'
+disable_node_classifier(master)
+
+step 'Disable environment caching'
+disable_env_cache(master)
+
+step 'Restart Puppet Server'
+restart_puppet_server(master)
+


### PR DESCRIPTION
This PR is to extend the acceptance testing of the azure module. Primarily it is to leverage both vagrant and vmpooler. The acceptance rake will allow for rake control of tasks allowing deviance from the default nodeset, to test master support OS variants.
