### PR TITLE
(CLOUD-419) Add complement of nodesets for acceptance testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,11 +40,6 @@ end
 
 PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run acceptance tests"
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
-
 # Use our own metadata task so we can ignore the non-SPDX PE licence
 Rake::Task[:metadata].clear
 desc "Check metadata is valid JSON"

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
@@ -53,7 +52,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">=3.7.0 <5.0.0"
+      "version_requirement": ">=3.8.0 < 2015.3.0"
     },
     {
       "name": "puppet",

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -1,0 +1,110 @@
+require 'rake/task_arguments'
+require 'rake/tasklib'
+require 'rake'
+
+# We clear the Beaker rake tasks from spec_helper as they assume
+# rspec-puppet and a certain filesystem layout
+Rake::Task[:beaker_nodes].clear
+Rake::Task[:beaker].clear
+
+module Beaker
+  module Tasks
+    class RakeTask < ::Rake::TaskLib
+      include ::Rake::DSL if defined?(::Rake::DSL)
+
+      [
+        :name,
+        :keyfile,
+        :config,
+        :debug,
+        :tests,
+        :pe_dir,
+      ].each do |sym|
+        attr_accessor(sym.to_sym)
+      end
+
+      def initialize(name, *args, &task_block)
+        @name = name
+        define(args, &task_block)
+      end
+
+      private
+      def run_task(verbose)
+        ENV['BEAKER_PE_DIR'] = pe_dir
+        system(beaker_command)
+      end
+
+      def define(args, &task_block)
+        task name, *args do |_, task_args|
+          RakeFileUtils.__send__(:verbose, verbose) do
+            task_block.call(*[self, task_args].slice(0, task_block.arity)) if task_block
+            run_task verbose
+          end
+        end
+      end
+
+      def beaker_command
+        cmd_parts = []
+        cmd_parts << "beaker"
+        cmd_parts << "--debug" if @debug
+        cmd_parts << "--config #{@config}"
+        cmd_parts << "--keyfile #{@keyfile}" if @keyfile
+        cmd_parts << "--test #{@tests}"
+        cmd_parts << "--pre-suite integration/pre-suite"
+        cmd_parts << "--load-path integration/lib"
+        cmd_parts << "--timeout 360"
+        cmd_parts.flatten.join(" ")
+      end
+    end
+  end
+end
+
+PE_RELEASES = {
+  '3.8.1' => 'http://pe-releases.puppetlabs.lan/3.8.1/',
+  '2015.2' => 'http://enterprise.delivery.puppetlabs.net/2015.2/preview/',
+}
+
+namespace :acceptance do
+  {
+    :vagrant => [
+      'ubuntu1404',
+      'centos7',
+      'centos6',
+      'ubuntu1404m_debian7a',
+      'ubuntu1404m_ubuntu1404a',
+      'centos7m_centos7a',
+      'centos6m_centos6a',
+    ],
+    :pooler => [
+      'ubuntu1404',
+      'centos7',
+      'centos6',
+      'ubuntu1404m_debian7a',
+      'ubuntu1404m_ubuntu1404a',
+      'centos7m_centos7a',
+      'centos6m_centos6a',
+      'rhel7',
+      'rhel7m_scientific7a',
+    ]
+  }.each do |ns, configs|
+    namespace ns.to_sym do
+      configs.each do |config|
+        PE_RELEASES.each do |version, pe_dir|
+          ENV['BEAKER_PE_DIR'] = pe_dir
+          ENV['BEAKER_set'] = "acceptance/nodesets/#{ns}/#{config}.yml"
+          desc "Run accpetance tests for #{config} on #{ns} with PE #{version}"
+          RSpec::Core::RakeTask.new("#{config}_#{version}".to_sym) do |t|
+            t.pattern = 'spec/acceptance'
+          end
+        end
+      end
+    end
+  end
+end
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  ENV['BEAKER_PE_DIR'] = ENV['BEAKER_PE_DIR'] || PE_RELEASES['2015.2']
+  ENV['BEAKER_set'] = ENV['BEAKER_set'] || 'acceptance/nodesets/vagrant/ubuntu1404.yml'
+  t.pattern = 'spec/acceptance'
+end

--- a/spec/acceptance/nodesets/pooler/centos6.yml
+++ b/spec/acceptance/nodesets/pooler/centos6.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos6:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/centos6m_centos6a.yml
+++ b/spec/acceptance/nodesets/pooler/centos6m_centos6a.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  centos6-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+  centos6-agent:
+    roles:
+      - agent
+      - default
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/centos7.yml
+++ b/spec/acceptance/nodesets/pooler/centos7.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos7:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/centos7m_centos7a.yml
+++ b/spec/acceptance/nodesets/pooler/centos7m_centos7a.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  centos7-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+  centos7-agent:
+    roles:
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/rhel7.yml
+++ b/spec/acceptance/nodesets/pooler/rhel7.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  rhel7:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/rhel7m_scientific7a.yml
+++ b/spec/acceptance/nodesets/pooler/rhel7m_scientific7a.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  rhel7-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+  scientific7-agent:
+    roles:
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/scientific-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/ubuntu1404.yml
+++ b/spec/acceptance/nodesets/pooler/ubuntu1404.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  ubuntu1404:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/ubuntu1404m_debian7a.yml
+++ b/spec/acceptance/nodesets/pooler/ubuntu1404m_debian7a.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  ubuntu1404-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  debian7-agent:
+    roles:
+      - agent
+      - default
+    platform: debian-7-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/debian-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/pooler/ubuntu1404m_ubuntu1404a.yml
+++ b/spec/acceptance/nodesets/pooler/ubuntu1404m_ubuntu1404a.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  ubuntu1404-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  ubuntu1404-agent:
+    roles:
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/nodesets/vagrant/centos6.yml
+++ b/spec/acceptance/nodesets/vagrant/centos6.yml
@@ -1,0 +1,17 @@
+HOSTS:
+  centos6:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/centos6m_centos6a.yml
+++ b/spec/acceptance/nodesets/vagrant/centos6m_centos6a.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  centos6-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+  centos6-agent:
+    roles:
+      - agent
+      - default
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/centos7.yml
+++ b/spec/acceptance/nodesets/vagrant/centos7.yml
@@ -1,0 +1,17 @@
+HOSTS:
+  centos7:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/centos7m_centos7a.yml
+++ b/spec/acceptance/nodesets/vagrant/centos7m_centos7a.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  centos7-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  centos7-agent:
+    roles:
+      - agent
+      - default
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/ubuntu1404.yml
+++ b/spec/acceptance/nodesets/vagrant/ubuntu1404.yml
@@ -1,0 +1,17 @@
+HOSTS:
+  ubuntu1404:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/ubuntu1404m_debian7a.yml
+++ b/spec/acceptance/nodesets/vagrant/ubuntu1404m_debian7a.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu1404-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+  debian7-agent:
+    roles:
+      - agent
+      - default
+    platform: debian-7-amd64
+    box: puppetlabs/debian-7.8-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-7.8-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false

--- a/spec/acceptance/nodesets/vagrant/ubuntu1404m_ubuntu1404a.yml
+++ b/spec/acceptance/nodesets/vagrant/ubuntu1404m_ubuntu1404a.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu1404-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+  ubuntu1404-agent:
+    roles:
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  consoleport: 443
+  vagrant_memsize: 2048
+  forge_host: api-module-staging.puppetlabs.com
+  color: false


### PR DESCRIPTION
This also includes a rake based interface to running the acceptance
tests against the nodesets with different PE versions and on different
hypervisors.
