### PR TITLE
(MAINT) Add code coverage output for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures
 .bundle
 vendor
 Gemfile.lock
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'rubocop', require: false
+  gem 'simplecov'
+  gem 'simplecov-console'
 end
 
 group :development do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,15 @@
 require 'azure'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'simplecov'
+require 'simplecov-console'
+
+SimpleCov.start do
+  add_filter '/spec'
+  formatter SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ]
+end
 
 RSpec.configure do |config|
   config.mock_with :rspec


### PR DESCRIPTION
This outputs a table after the test run with the coverage details, as
well as outputting a set of HTML pages with the coverage details. It
would be possible to add other formatters (including something like
Coveralls) later on to track this over time.

As an example, here's what you get at the bottom of the tests. Especially with guard running this is super helpful in my view.

```
Coverage report generated for RSpec to /Users/garethr/Documents/puppetlabs-msazure/coverage. 179 / 220 LOC (81.36%) covered.

COVERAGE:  81.36% -- 179/220 lines in 10 files

+----------+--------------------------------------------+-------+--------+---------------------------------------------+
| coverage | file                                       | lines | missed | missing                                     |
+----------+--------------------------------------------+-------+--------+---------------------------------------------+
|  43.33%  | lib/puppet_x/puppetlabs/azure/provider.rb  | 30    | 17     | 8-10, 16, 20, 24-27, 32-33, 39, 46-49, 51   |
|  43.33%  | lib/puppet/provider/azure_vm/azure_sdk.rb  | 30    | 17     | 12, 15-17, 19-21, 27-28, 39, 43-44, 48-4... |
|  66.67%  | lib/puppet_x/puppetlabs/azure/prefetch_... | 9     | 3      | 10-11, 15                                   |
|  85.71%  | lib/puppet_x/puppetlabs/azure/property/... | 7     | 1      | 7                                           |
|  90.00%  | lib/puppet_x/puppetlabs/azure/property/... | 10    | 1      | 7                                           |
|  97.53%  | lib/puppet/type/azure_vm.rb                | 81    | 2      | 194, 200                                    |
+----------+--------------------------------------------+-------+--------+---------------------------------------------+
```
