### PR TITLE
(CLOUD-435, CLOUD-433) Connectivity and availability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
 end
 
 group :acceptance do
+  gem 'winrm', '~> 1.3'
   gem 'mustache'
   gem 'ssh-exec'
   gem 'retries'

--- a/README.md
+++ b/README.md
@@ -209,13 +209,13 @@ user.
 The storage account to associate the virtual machine with.
 
 #####`winrm_transport`
-A list of transport protocols for WINRM.
+A list of transport protocols for WinRM.
 
 #####`winrm_https_port`
-The port number of WINRM https communication.
+The port number for WinRM https communication. Defaults to 5986
 
 #####`winrm_http_port`
-The port number of WINRM http communication.
+The port number for WinRM http communication. Defaults to 5985
 
 #####`cloud_service`
 The name of the associated cloud service.
@@ -224,7 +224,7 @@ The name of the associated cloud service.
 The name for the deployment.
 
 #####`ssh_port`
-The port number for SSH.
+The port number for SSH. Defaults to 22
 
 #####`size`
 The size of the virtual machine instance. See the Azure documentation

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,5 +1,5 @@
 azure_vm { 'garethr':
-  ensure           => present,
+  ensure           => stopped,
   image            => 'b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2-LTS-amd64-server-20150706-en-us-30GB',
   location         => 'West US',
   user             => 'garethr',

--- a/lib/puppet/provider/azure_vm/azure_sdk.rb
+++ b/lib/puppet/provider/azure_vm/azure_sdk.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_sdk, :parent => PuppetX::Puppetlabs:
     end
   end
 
-  def self.machine_to_hash(machine)
+  def self.machine_to_hash(machine) # rubocop:disable Metrics/AbcSize
     status = case machine.status
              when 'StoppedDeallocated', 'Stopped'
                :stopped
@@ -40,11 +40,12 @@ Puppet::Type.type(:azure_vm).provide(:azure_sdk, :parent => PuppetX::Puppetlabs:
                :running
              end
     cloud_service = get_cloud_service(machine.cloud_service_name)
+    location = cloud_service.location || cloud_service.extended_properties["ResourceLocation"]
     {
       name: machine.vm_name,
       image: machine.image,
       ensure: status,
-      location: cloud_service.location,
+      location: location,
       deployment: machine.deployment_name,
       cloud_service: machine.cloud_service_name,
       os_type: machine.os_type,
@@ -77,6 +78,10 @@ Puppet::Type.type(:azure_vm).provide(:azure_sdk, :parent => PuppetX::Puppetlabs:
       cloud_service_name: resource[:cloud_service],
       availability_set_name: resource[:availability_set],
       affinity_group_name: resource[:affinity_group],
+      winrm_https_port: resource[:winrm_https_port],
+      winrm_http_port: resource[:winrm_http_port],
+      winrm_transport: resource[:winrm_transport],
+      ssh_port: resource[:ssh_port],
     }
     create_vm(params)
   end

--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -132,27 +132,27 @@ Puppet::Type.newtype(:azure_vm) do
     desc 'The storage account to associate the virtual machine with.'
   end
 
-  newproperty(:winrm_transport, :parent => PuppetX::PuppetLabs::Azure::Property::String, :array_matching => :all) do
+  newparam(:winrm_transport, :parent => PuppetX::PuppetLabs::Azure::Property::String, :array_matching => :all) do
     desc 'A list of transport protocols for WINRM.'
   end
 
-  newproperty(:winrm_https_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
+  newparam(:winrm_https_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
     desc 'The port number of WINRM https communication.'
   end
 
-  newproperty(:winrm_http_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
-    desc 'The port number of WINRM http communication.'
+  newparam(:winrm_http_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
+    desc 'The port number for WinRM http communication. Defaults to 5985.'
   end
 
   newproperty(:cloud_service, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
-    desc 'The name of the associated cloud service.'
+    desc 'The port number for WinRM https communication. Defaults to 5986.'
   end
 
   newproperty(:deployment, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
     desc 'The name for the deployment.'
   end
 
-  newproperty(:ssh_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
+  newparam(:ssh_port, :parent => PuppetX::PuppetLabs::Azure::Property::PositiveInteger) do
     desc 'The port number for SSH.'
   end
 

--- a/spec/acceptance/minimal_properties_spec.rb
+++ b/spec/acceptance/minimal_properties_spec.rb
@@ -38,6 +38,11 @@ describe 'azure_vm when creating a new machine with the minimum properties' do
     expect(@client.get_cloud_service(@machine).location).to eq (@config[:optional][:location])
   end
 
+  it 'should have the default SSH port' do
+    ssh_endpoint = @machine.tcp_endpoints.find { |endpoint| endpoint[:name] == 'SSH' }
+    expect(ssh_endpoint[:public_port]).to eq('22')
+  end
+
   it 'is accessible using the private key' do
     result = run_command_over_ssh('true', 'publickey')
     expect(result.exit_status).to eq 0

--- a/spec/acceptance/windows_machine_spec.rb
+++ b/spec/acceptance/windows_machine_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+describe 'azure_vm when creating a new Windows machine' do
+  include_context 'with certificate copied to system under test'
+
+  before(:all) do
+    # Windows machines can't have names longer than 15 characters
+    @name = "CLOUD-#{SecureRandom.hex(4)}"
+
+    @config = {
+      name: @name,
+      ensure: 'present',
+      optional: {
+        image: WINDOWS_IMAGE,
+        location: CHEAPEST_AZURE_LOCATION,
+        user: 'specuser',
+        password: 'SpecPass123!@#$%',
+        winrm_https_port: 5986,
+        winrm_transport: ['https'],
+      }
+    }
+    @manifest = PuppetManifest.new(@template, @config)
+    @result = @manifest.execute
+    @machine = @client.get_virtual_machine(@name).first
+    @ip = @machine.ipaddress
+  end
+
+  it_behaves_like 'an idempotent resource'
+
+  include_context 'destroys created resources after use'
+
+  it 'should have the correct image' do
+    expect(@machine.image).to eq(@config[:optional][:image])
+  end
+
+  it 'should be accessible via WinRM with the provided details' do
+    pending 'the Azure firewall is not by default open to WinRM, pending work in CLOUD-429'
+    run_command_over_winrm('ipconfig /all', @config[:optional][:winrm_https_port]) do |stdout, stderr|
+      expect(stderr).to be_empty?
+    end
+  end
+
+  context 'when looked for using puppet resource' do
+    include_context 'a puppet resource run'
+    puppet_resource_should_show('os_type', 'Windows')
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,6 +6,7 @@ require 'beaker'
 require 'net/ssh'
 require 'ssh-exec'
 require 'retries'
+require 'winrm'
 
 # automatically load any shared examples or contexts
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f}
@@ -14,6 +15,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f}
 CHEAPEST_AZURE_LOCATION="East US"
 
 UBUNTU_IMAGE='b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2-LTS-amd64-server-20150706-en-us-30GB'
+WINDOWS_IMAGE='a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-20150825-en.us-127GB.vhd'
 
 unless ENV['PUPPET_AZURE_BEAKER_MODE'] == 'local'
   require 'beaker-rspec'
@@ -344,21 +346,47 @@ def expect_failed_apply(config)
   expect(result.exit_code).not_to eq 0
 end
 
-def run_command_over_ssh(command, auth_method)
+def run_command_over_ssh(command, auth_method, port=22)
   # We retry failed attempts as although the VM has booted it takes some
   # time to start and expose SSH. This mirrors the behaviour of a typical SSH client
+  allowed_errors = [
+    # The following errors can occur if we try and connect after the machine has
+    # been created but before cloud-init provisions the machine
+    Net::SSH::HostKeyMismatch,
+    Net::SSH::AuthenticationFailed,
+    # The following errors can occur before the machine has been created
+    # and we retry until it exists
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::ETIMEDOUT,
+  ]
   with_retries(:max_tries => 10,
                :base_sleep_seconds => 20,
                :max_sleep_seconds => 20,
-               :rescue => [Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT]) do
+               :rescue => allowed_errors) do
     Net::SSH.start(@ip,
                    @config[:optional][:user],
+                   :port => port,
                    :password => @config[:optional][:password],
                    :keys => [@local_private_key_path],
                    :auth_methods => [auth_method],
                    :verbose => :info) do |ssh|
       SshExec.ssh_exec!(ssh, command)
     end
+  end
+end
+
+def run_command_over_winrm(command, port=5986)
+  endpoint = "https://#{@machine.ipaddress}:#{port}/wsman"
+  winrm = WinRM::WinRMWebService.new(
+    endpoint,
+    :ssl,
+    user: @config[:optional][:user],
+    pass: @config[:optional][:password],
+    disable_sspi: true,
+  )
+  with_retries(:max_tries => 5) do
+    winrm.cmd(command)
   end
 end
 

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -10,6 +10,10 @@ describe type_class do
       :password,
       :private_key_file,
       :affinity_group,
+      :winrm_transport,
+      :winrm_https_port,
+      :winrm_http_port,
+      :ssh_port,
     ]
   end
 
@@ -19,12 +23,8 @@ describe type_class do
       :image,
       :location,
       :storage_account,
-      :winrm_transport,
-      :winrm_https_port,
-      :winrm_http_port,
       :cloud_service,
       :deployment,
-      :ssh_port,
       :size,
       :virtual_network,
       :subnet,


### PR DESCRIPTION
Note that this should be merged after the disks work in CLOUD-430. The temporary availability sets created in the tests are not cleaned up, or rather the cleanup fails, because of the hanging disks. This can be resolved by passing the `purge` option from the disks work once it's ready.

Also note that one of the tests is left pending, as it relies on the endpoint work.
