### PR TITLE
(MAINT) Fix issue loading simplecov formatters with latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'puppetlabs_spec_helper', '< 1.0'
   gem 'metadata-json-lint'
   gem 'rubocop', '0.33.0', require: false
-  gem 'simplecov'
+  gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
   gem 'parallel_tests'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,10 @@ require 'simplecov-console'
 
 SimpleCov.start do
   add_filter '/spec'
-  formatter SimpleCov::Formatter::MultiFormatter[
+  formatter SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console
-  ]
+  ])
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This was reported against the module skeleton. It only triggers with
SimpleCov 0.11.0 which was released a few days ago.
