### PR TITLE
(maint) Fix errant URLS in README / metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Defaults to `Dynamic`.
 The Network Interface Controller (nic) name for the virtual machine.
 
 ##Limitations
-Due to the dependencies of the Azure Classic SDK (nokogiri), running the module on a Windows Agent is only supported with puppet-agent 1.3.0 (a part of Puppet Enterprise 2015.3) which preinstalls nokogiri.
+Due to a Ruby Azure SDK dependency on the nokogiri gem, running the module on a Windows Agent is only supported with puppet-agent 1.3.0 (a part of Puppet Enterprise 2015.3) and newer.  In that situation, the correct version of nokogiri will be installed when performing the `gem install azure` command mentioned in [Installing the Azure module](#installing-the-azure-module).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-Status](https://magnum.travis-ci.com/puppetlabs/puppetlabs-msazure.svg?token=RqtxRv25TsPVz69Qso5L)](https://magnum.travis-ci.com/puppetlabs/puppetlabs-msazure)
+Status](https://magnum.travis-ci.com/puppetlabs/puppetlabs-azure.svg?token=RqtxRv25TsPVz69Qso5L)](https://magnum.travis-ci.com/puppetlabs/puppetlabs-azure)
 
 ####Table of Contents
 
@@ -145,7 +145,7 @@ updated path:
 3. Finally, install the module with:
 
    ~~~
-   puppet module install puppetlabs-msazure
+   puppet module install puppetlabs-azure
    ~~~
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Create and manage machines running on Microsoft Azure with Puppet",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-azure",
-  "project_page": "https://forge.puppetlabs.com/puppetlabs/azure",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-azure",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,16 @@
       "operatingsystemrelease": [
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2",
+        "7",
+        "8"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
 - Project page for this module should be the puppetlabs-azure repo
 - README still contained a link to TravisCI at puppetlabs-msazure