### PR TITLE
Correct name length error check

### DIFF
--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -67,7 +67,7 @@ Puppet::Type.newtype(:azure_vm) do
     desc 'Name of the virtual machine.'
     validate do |value|
       super value
-      fail("the name must be less that 16 characters in length") if value.size > 15
+      fail("the name must be between 1 and 64 characters long") if value.size > 64
     end
   end
 

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -225,15 +225,15 @@ describe 'azure_vm', :type => :type do
     end
   end
 
-  context 'with a name greater than 15 characters' do
+  context 'with a name greater than 64 characters' do
     let :config do
       result = default_config
-      result[:name] = SecureRandom.hex(8)
+      result[:name] = SecureRandom.hex(33)
       result
     end
 
     it 'should be invalid' do
-      expect { type_class.new(config) }.to raise_error(Puppet::Error, /the name must be less that 16 characters/)
+      expect { type_class.new(config) }.to raise_error(Puppet::Error, /the name must be between 1 and 64 characters long/)
     end
   end
 


### PR DESCRIPTION
Related to Puppet Labs Support Request #16778.  Azure VM (ARM) name length is 64 characters according to GUI.