### PR TITLE
Fix quote interpolation

### DIFF
--- a/spec/acceptance/arm_vm_spec.rb
+++ b/spec/acceptance/arm_vm_spec.rb
@@ -33,6 +33,8 @@ describe 'azure_vm when creating a machine with all available properties' do
         ip_configuration_name: 'ip_config_test01',
         private_ip_allocation_method: 'Dynamic',
         network_interface_name: 'nicspec01',
+      },
+      nonstring: {
         extensions: {
           'CustomScriptForLinux' => {
             'auto_upgrade_minor_version' => false,

--- a/spec/acceptance/fixtures/azure_vm.pp.tmpl
+++ b/spec/acceptance/fixtures/azure_vm.pp.tmpl
@@ -3,4 +3,7 @@ azure_vm { '{{name}}':
   {{#optional}}
   {{k}}   => '{{v}}',
   {{/optional}}
+  {{#nonstring}}
+  {{k}}   => {{{v}}},
+  {{/nonstring}}
 }


### PR DESCRIPTION
Mustash interpolate strings and incorrectly quotes them. This allows non
string values to be added to the manifest templates without HTML
interpolation.