### PR TITLE
(MODULES-3614) Add data_disks to azure_vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,35 @@ Defaults to `Dynamic`.
 ##### `network_interface_name`
 The Network Interface Controller (nic) name for the virtual machine.
 
+##### `data_disks`
+Manage one or more data disks attached to an Azure VM. This parameter expects a hash where the key is the name of the data disk and the value is a hash of data disk properties.
+
+Azure VM data_disks support the following parameters:
+
+###### `caching`
+Optional. Specifies the caching behavior of data disk.
+
+Possible values are:
+- None
+- ReadOnly
+- ReadWrite
+The default vault is None.
+
+###### `create_option`
+Specifies the create option for the disk image. Possible values for this property include: 'FromImage', 'Empty', 'Attach'.
+
+###### `data_size_gb`
+Specifies the size, in GB, of an empty disk to be attached to the Virtual Machine.
+
+###### `lun`
+Specifies the Logical Unit Number (LUN) for the disk. The LUN specifies the slot in which the data drive appears when mounted for usage by the Virtual Machine. Valid LUN values are 0 through 31.
+
+###### `vhd`
+Specifies the location of the blob in storage where the vhd file for the disk is located. The storage account where the vhd is located must be associated with the specified subscription.
+
+Example:
+`http://example.blob.core.windows.net/disks/mydisk.vhd`
+
 ##### `extensions`
 The extension to configure on the VM. Azure VM Extensions implement behaviors or features that either help other programs work on Azure VMs. You can optionally configure this parameter to include an extension.
 This parameter can be either a single hash (single extension) or multiple hashes (multiple extensions).

--- a/spec/acceptance/arm_vm_datadisks_spec.rb
+++ b/spec/acceptance/arm_vm_datadisks_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper_acceptance'
+
+describe 'azure_vm when creating a machine with all available properties' do
+  include_context 'with a known name and storage account name'
+  include_context 'destroy left-over created ARM resources after use'
+
+  before(:all) do
+    @config = {
+      name: @name,
+      ensure: 'present',
+      location: CHEAPEST_ARM_LOCATION,
+      resource_group: SPEC_RESOURCE_GROUP,
+      optional: {
+        image: 'CoreOS:CoreOS:Stable:latest',
+        network_interface_name: 'nicspec01',
+        os_disk_caching: 'ReadWrite',
+        os_disk_create_option: 'FromImage',
+        os_disk_name: 'osdisk01',
+        os_disk_vhd_container_name: 'conttest1',
+        os_disk_vhd_name: 'osvhdtest1',
+        size: 'Standard_DS1_v2',
+        user: 'specuser',
+        password: 'SpecPass123!@#$%',
+      },
+      nonstring: {
+        data_disks: {
+          'spec1' => {
+            'caching'       => 'ReadWrite',
+            'disk_size_gb'  => '15',
+            'lun'           => '1',
+            'vhd'           => 'https://slowspacespec.blob.core.windows.net/wat/another.vhd',
+          },
+          'spec2' => {
+            'caching'       => 'ReadOnly',
+            'create_option' => 'Empty',
+            'disk_size_gb'  => '128',
+            'lun'           => '0',
+            'vhd'           => 'https://hunnerdisks861.blob.core.windows.net/vhds/some_name_here.vhd',
+          },
+        },
+      },
+    }
+    @template = 'azure_data_disks.pp.tmpl'
+    @client = AzureARMHelper.new
+    @manifest = PuppetManifest.new(@template, @config)
+    @result = @manifest.execute
+    @machine = @client.get_vm(@name)
+  end
+
+  it_behaves_like 'an idempotent resource'
+
+  it 'should have the correct name' do
+    expect(@machine.name).to eq(@name)
+  end
+
+  it 'should have the correct size' do
+    expect(@machine.properties.hardware_profile.vm_size).to eq(@config[:optional][:size])
+  end
+
+  it 'should be running' do
+    expect(@client.vm_running?(@machine)).to be true
+  end
+
+  context 'when we try and change the disks' do
+    before(:all) do
+      @config[:nonstring][:data_disks]['spec2']['caching'] = 'ReadWrite'
+      @manifest = PuppetManifest.new(@template, @config)
+      @result = @manifest.execute
+      @machine = @client.get_vm(@name)
+    end
+
+    it_behaves_like 'an idempotent resource'
+
+    context 'when looked for using puppet resource' do
+      include_context 'a puppet ARM resource run'
+      puppet_resource_should_show('caching', 'ReadWrite')
+    end
+  end
+end

--- a/spec/acceptance/fixtures/azure_data_disks.pp.tmpl
+++ b/spec/acceptance/fixtures/azure_data_disks.pp.tmpl
@@ -1,0 +1,27 @@
+azure_resource_group { '{{resource_group}}':
+  ensure   => present,
+  location => '{{location}}',
+}
+azure_storage_account { 'slowspacespec':
+  ensure         => present,
+  account_type   => 'Standard_GRS',
+  location       => '{{location}}',
+  resource_group => '{{resource_group}}',
+}
+-> azure_storage_account { 'hunnerdisks861':
+  ensure         => present,
+  account_type   => 'Standard_GRS',
+  location       => '{{location}}',
+  resource_group => '{{resource_group}}',
+}
+-> azure_vm { '{{name}}':
+  ensure         => {{ensure}},
+  resource_group => '{{resource_group}}',
+  location       => '{{location}}',
+  {{#optional}}
+  {{k}}   => '{{v}}',
+  {{/optional}}
+  {{#nonstring}}
+  {{k}}   => {{{v}}},
+  {{/nonstring}}
+}


### PR DESCRIPTION
This adds data_disks property that expects a hash of hashes. The key
should be the name of the disk and the hash contains up to five
properties that apply to the disk. The subhash is caching,
create_option, data_size_gb, lun, and vhd.