### PR TITLE
Fix test of customdata on azure_vm

### DIFF
--- a/lib/puppet_x/puppetlabs/azure/provider_arm.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_arm.rb
@@ -309,6 +309,14 @@ module PuppetX
           ProviderArm.network_client.public_ipaddresses.create_or_update(args[:resource_group], args[:public_ip_address_name], params).value!.body
         end
 
+        def get_network_interface(resource_group, network_interface_name)
+          ProviderArm.network_client.network_interfaces.get(resource_group, network_interface_name)
+        end
+
+        def get_public_ip_address(resource_group, public_ip_address_name)
+          ProviderArm.network_client.public_ipaddresses.get(resource_group, public_ip_address_name)
+        end
+
         def create_subnet(virtual_network, args)
           params = build_subnet_params(args)
           ProviderArm.network_client.subnets.create_or_update(

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -208,7 +208,7 @@ class AzureARMHelper
   end
 
   def self.network_client
-    @network_client ||= AzureARMHelper.with_subscription_id ::Azure::ARM::Network::NetworkResourceProviderClient.new(credentials)
+    @network_client ||= AzureARMHelper.with_subscription_id ::Azure::ARM::Network::NetworkManagementClient.new(credentials)
   end
 
   def self.storage_client
@@ -262,6 +262,14 @@ class AzureARMHelper
   def get_storage_account(name)
     accounts = list_storage_accounts
     accounts.find { |x| x.name == name }
+  end
+
+  def get_network_interface(resource_group, network_interface_name)
+    AzureARMHelper.network_client.network_interfaces.get(resource_group, network_interface_name)
+  end
+
+  def get_public_ip_address(resource_group, public_ip_address_name)
+    AzureARMHelper.network_client.public_ipaddresses.get(resource_group, public_ip_address_name)
   end
 
   def destroy_storage_account(resource_group_name, name)


### PR DESCRIPTION
Previously the test tried to use `@machine.ip` to access the public IP
address of the newly created azure instance, just like the similar test
in `azure_vm_classic`. This doesn't work, so we need new methods to find
the public ip address of the azure ARM instance before the test can pass.