### PR TITLE
Use parallel_tests 2.9.0 for ruby < 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'rubocop', '~> 0.41.0'
   gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
-  gem 'parallel_tests'
+  gem 'parallel_tests', '2.9.0' if RUBY_VERSION < '2.0.0'
   gem 'listen', '~> 3.0.0'
 end
 


### PR DESCRIPTION
Parallel_tests 2.10.0 requires ruby >= 2.0.0, so for jobs with
ruby < 2.0.0 parallel_tests 2.9.0 should be used.