### PR TITLE
(FM-5488) Fix plan for azure_vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,17 +240,21 @@ azure_vm { 'sample':
 }
 ~~~
 
-You can also add a [virtual machine extension](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-extensions-features/) to the VM:
+You can also add a [virtual machine extension](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-extensions-features/) to the VM and deploy from a [Marketplace product](https://azure.microsoft.com/en-us/blog/working-with-marketplace-images-on-azure-resource-manager/) instead of an image:
 
 ~~~puppet
 azure_vm { 'sample':
   ensure         => present,
   location       => 'eastus',
-  image          => 'canonical:ubuntuserver:14.04.2-LTS:latest',
   user           => 'azureuser',
   password       => 'Password_!',
   size           => 'Standard_A0',
   resource_group => 'testresacc01',
+  plan           => {
+    'name'      => '2016-1',
+    'product'   => 'puppet-enterprise',
+    'publisher' => 'puppet',
+  },
   extensions     => {
     'CustomScriptForLinux' => {
        'auto_upgrade_minor_version' => false,
@@ -295,11 +299,6 @@ azure_vm { 'sample':
   ip_configuration_name         => 'ip_config_test01',
   private_ip_allocation_method  => 'Dynamic',
   network_interface_name        => 'nicspec01',
-  plan                          => {
-    'name'      => '2016-1',
-    'product'   => 'puppet-enterprise',
-    'publisher' => 'puppet',
-  },
   extensions                    => {
     'CustomScriptForLinux' => {
        'auto_upgrade_minor_version' => false,
@@ -605,7 +604,7 @@ Values have the following effects:
 *Required* The name of the virtual machine. The name may have at most 64 characters. Some images may have more restrictive requirements.
 
 ##### `image`
-*Required* Name of the image to use to create the virtual machine. This must be in the ARM image_refence format
+Name of the image to use to create the virtual machine. Required if no Marketplace `plan` is provided. This must be in the ARM image_refence format
 [Azure image reference](https://azure.microsoft.com/en-gb/documentation/articles/virtual-machines-deploy-rmtemplates-azure-cli/)
 
 ~~~
@@ -735,7 +734,7 @@ Example:
 `http://example.blob.core.windows.net/disks/mydisk.vhd`
 
 ##### `plan`
-Deploys the VM from an Azure Software Marketplace product (called a "plan"). The value must be a hash with three required keys: `name`, `product`, and `publisher`. `promotion_code` is an optional forth key that may be passed.
+Deploys the VM from an Azure Software Marketplace product (called a "plan"). Required if no `image` is specified. The value must be a hash with three required keys: `name`, `product`, and `publisher`. `promotion_code` is an optional forth key that may be passed.
 
 As an example:
 

--- a/examples/data_disks.pp
+++ b/examples/data_disks.pp
@@ -1,0 +1,49 @@
+azure_resource_group { 'hunner':
+  ensure   => present,
+  location => 'westus',
+}
+azure_storage_account { 'slowspace':
+  ensure         => present,
+  location       => 'westus',
+  account_type   => 'Standard_GRS',
+  resource_group => 'hunner',
+  before         => Azure_vm['candy'],
+}
+azure_storage_account { 'hunnerdisks861':
+  ensure         => present,
+  location       => 'westus',
+  account_type   => 'Standard_GRS',
+  resource_group => 'hunner',
+  before         => Azure_vm['candy'],
+}
+azure_vm { 'candy':
+  ensure                     => 'running',
+  image                      => 'CoreOS:CoreOS:Stable:latest',
+  location                   => 'westus',
+  network_interface_name     => 'candy891',
+  os_disk_caching            => 'ReadWrite',
+  os_disk_create_option      => 'FromImage',
+  os_disk_name               => 'candy',
+  os_disk_vhd_container_name => 'vhds',
+  os_disk_vhd_name           => 'candy2016726122234',
+  resource_group             => 'hunner',
+  size                       => 'Standard_DS1_v2',
+  user                       => 'hunner',
+  password                   => '1N53cure!',
+  data_disks                 => {
+    'some_name_here' => {
+      'caching'       => 'ReadOnly',
+      'create_option' => 'Empty',
+      'disk_size_gb'  => '128',
+      'lun'           => '0',
+      'vhd'           => 'https://hunnerdisks861.blob.core.windows.net/vhds/some_name_here.vhd',
+      },
+      'another'      => {
+        'caching'       => 'None',
+        'create_option' => 'Empty',
+        'disk_size_gb'  => '15',
+        'lun'           => '1',
+        'vhd'           => 'https://slowspace.blob.core.windows.net/wat/another.vhd',
+      },
+  },
+}

--- a/examples/pe_plan.pp
+++ b/examples/pe_plan.pp
@@ -1,0 +1,13 @@
+azure_vm { 'puppetmaster':
+  ensure         => 'running',
+  location       => 'westus',
+  resource_group => 'hunner-plan',
+  size           => 'Standard_A0',
+  user           => 'hunner',
+  password       => '1N53cure!',
+  plan           => {
+    'name'      => '2016-1',
+    'product'   => 'puppet-enterprise',
+    'publisher' => 'puppet',
+  },
+}

--- a/lib/puppet_x/puppetlabs/azure/provider_arm.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_arm.rb
@@ -345,12 +345,20 @@ module PuppetX
           "#{container}/#{args[:os_disk_vhd_name]}.vhd"
         end
 
-        def build_image_reference(args)
+        def build_image_reference(args) # rubocop:disable Metrics/AbcSize
+          if ! args[:plan]
+            publisher, offer, sku, version = args[:image].split(':')
+          else
+            publisher = args[:plan]['publisher']
+            offer = args[:plan]['product']
+            sku = args[:plan]['name']
+            version = args[:plan]['version'] || 'latest'
+          end
           build(::Azure::ARM::Compute::Models::ImageReference, {
-            publisher: args[:image].split(':')[0],
-            offer: args[:image].split(':')[1],
-            sku: args[:image].split(':')[2],
-            version: args[:image].split(':')[3],
+            publisher: publisher,
+            offer: offer,
+            sku: sku,
+            version: version,
           })
         end
 
@@ -503,12 +511,14 @@ module PuppetX
         end
 
         def build_plan(args)
-          build(::Azure::ARM::Compute::Models::Plan, {
-            name: args[:plan]['name'],
-            publisher: args[:plan]['publisher'],
-            product: args[:plan]['product'],
-            promotion_code: args[:plan]['promotion_code'],
-          })
+          if args[:plan]
+            build(::Azure::ARM::Compute::Models::Plan, {
+              name: args[:plan]['name'],
+              publisher: args[:plan]['publisher'],
+              product: args[:plan]['product'],
+              promotion_code: args[:plan]['promotion_code'],
+            })
+          end
         end
 
         def build_props(args)

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -41,6 +41,7 @@ PE_RELEASES = {
   '3.8.1' => 'http://pe-releases.puppetlabs.lan/3.8.1/',
   '2015.2' => 'http://pe-releases.puppetlabs.lan/2015.2.3/',
   '2015.3' => 'http://enterprise.delivery.puppetlabs.net/2015.3/preview/',
+  '2016.2' => 'http://pe-releases.puppetlabs.lan/2016.2.1/',
 }.freeze
 
 desc "Run acceptance tests"

--- a/spec/acceptance/arm_vm_datadisks_spec.rb
+++ b/spec/acceptance/arm_vm_datadisks_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'azure_vm when creating a machine with all available properties' do
+describe 'azure_vm when creating a machine with datadisks' do
   include_context 'with a known name and storage account name'
   include_context 'destroy left-over created ARM resources after use'
 
@@ -12,7 +12,7 @@ describe 'azure_vm when creating a machine with all available properties' do
       resource_group: SPEC_RESOURCE_GROUP,
       optional: {
         image: 'CoreOS:CoreOS:Stable:latest',
-        network_interface_name: 'nicspec01',
+        network_interface_name: 'diskspec01',
         os_disk_caching: 'ReadWrite',
         os_disk_create_option: 'FromImage',
         os_disk_name: 'osdisk01',

--- a/spec/acceptance/arm_vm_plan_spec.rb
+++ b/spec/acceptance/arm_vm_plan_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper_acceptance'
+
+describe 'azure_vm when creating a machine with a plan' do
+  include_context 'with certificate copied to system under test'
+  include_context 'with a known name and storage account name'
+  include_context 'destroy left-over created ARM resources after use'
+
+  before(:all) do
+    @custom_data_file = '/tmp/needle'
+    @config = {
+      name: @name,
+      ensure: 'present',
+      optional: {
+        location: CHEAPEST_ARM_LOCATION,
+        user: 'specuser',
+        size: 'Standard_A0',
+        resource_group: SPEC_RESOURCE_GROUP,
+        password: 'SpecPass123!@#$%',
+      },
+      nonstring: {
+        plan: {
+          'name'      => '2016-1',
+          'product'   => 'puppet-enterprise',
+          'publisher' => 'puppet',
+        },
+      },
+    }
+    @template = 'azure_vm.pp.tmpl'
+    @client = AzureARMHelper.new
+    @manifest = PuppetManifest.new(@template, @config)
+    @result = @manifest.execute
+    @machine = @client.get_vm(@name)
+    @ip = @client.get_public_ip_address(
+      SPEC_RESOURCE_GROUP,
+      @client.get_network_interface(
+        SPEC_RESOURCE_GROUP,
+        @machine.properties.network_profile.network_interfaces.first.id.split('/').last
+      ).properties.ip_configurations.first.properties.public_ipaddress.id.split('/').last
+    ).properties.ip_address
+  end
+
+  it_behaves_like 'an idempotent resource'
+
+  it 'should have the correct name' do
+    expect(@machine.name).to eq(@name)
+  end
+
+  it 'should be running' do
+    expect(@client.vm_running?(@machine)).to be true
+  end
+
+  context 'when puppet resource is run' do
+    include_context 'a puppet ARM resource run'
+    puppet_resource_should_show('ensure', 'running')
+    puppet_resource_should_show('location', 'eastus')
+    puppet_resource_should_show('plan')
+    puppet_resource_should_show('user')
+    puppet_resource_should_show('size')
+    puppet_resource_should_show('resource_group')
+  end
+
+  context 'when we try and destroy the VM' do
+    before(:all) do
+      new_config = @config.update({:ensure => 'absent'})
+      manifest = PuppetManifest.new(@template, new_config)
+      @result = manifest.execute
+      @machine = @client.get_vm(@name)
+    end
+
+    it 'should run without errors' do
+      expect(@result.exit_code).to eq 2
+    end
+
+    it 'should be destroyed' do
+      expect(@machine).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Using `plan` is incompatible with `image` though one of the two is
required.

Also fixes extension testing (via removing broken dns), avoids
conflicting network interface names during testing, and adds 2016.2
acceptance test rake jobs.