### PR TITLE
(MODULES-5036) azure gem upgrades for new features 3/6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'azure', '~> 0.7.0'
 
-gem 'azure_mgmt_storage', '~> 0.3.0'
-gem 'azure_mgmt_compute', '~> 0.3.0'
-gem 'azure_mgmt_resources', '~> 0.3.0'
-gem 'azure_mgmt_network', '~> 0.3.0'
+gem 'azure_mgmt_storage', '~> 0.10.0'
+gem 'azure_mgmt_compute', '~> 0.10.0'
+gem 'azure_mgmt_resources', '~> 0.10.0'
+gem 'azure_mgmt_network', '~> 0.10.0'
 
 gem 'hocon'
 gem 'retries'

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppetlabs/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 
@@ -86,10 +86,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     gem install retries --no-ri --no-rdoc
     gem install azure --version="~>0.7.0" --no-ri --no-rdoc
-    gem install azure_mgmt_compute --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_storage --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_resources --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_network --version="~>0.3.0" --no-ri --no-rdoc
+    gem install azure_mgmt_compute --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_storage --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_resources --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_network --version="~>0.10.0" --no-ri --no-rdoc
     gem install hocon --version="~>1.1.2" --no-ri --no-rdoc
     ```
 
@@ -98,10 +98,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ azure_vm { 'ssd-example':
 
 To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
 
+#### Boot/guest diagnostics
+The Azure portal provides switches to enable _boot_diagnostics_ and _guest diagnostics_.  Both of which require access to a storage account to dump the diagnostic data.
+
+The switch which behaves differenly depending what was activated:
+* Boot diagnostics - Configures the VM `diagnosticsProfile` setting to write out boot diagnostics .  Enabled manually via the portal if required.  Since boot diagnostics only apply at boot time, their most useful for interactive debugging when a VM is having a problems booting.  If required, boot diagnostics can be enabled through the Azure portal.
+* Guest diagnostics - Configures an extension to capture live diagnostic output.  This needs to be _different_ depending on the selected guest OS and is enabled by supplying the appropriate data to the `extensions` parameter.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -300,6 +300,26 @@ azure_vm { 'sample':
 }
 ```
 
+#### Premium Storage
+
+Azure supports _premium_ SSD backed VMs for enhanced performance of production class environments.  SSD storage can be selected at the time of VM creation like this (`Premium_LRS` is the Azure API's internal representation):
+
+```puppet
+azure_vm { 'ssd-example':
+  ensure               => present,
+  location             => 'centralus',
+  image                => 'Canonical:UbuntuServer:16.10:latest',
+  user                 => 'azureuser',
+  password             => 'Password_!',
+  size                 => 'Standard_DS1_v2',
+  resource_group       => 'puppetvms',
+  storage_account_type => 'Premium_LRS',
+}
+
+```
+
+To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:


### PR DESCRIPTION
Upgrade gems:
* azure_mgmt_compute (0.10.0)
* azure_mgmt_network (0.10.0)
* azure_mgmt_resources (0.10.0)
* azure_mgmt_storage (0.10.0)

To enable support of new azure features such as "managed disks".  `rake spec` passing after code refactor and am able to provision vms using `azure_vm`, however, unable to acceptance test given need to access puppet internal test resources to perform them.  The `data_disks` parameter is not updatable (although it works on create) after applying this patch but I think it may have been broken before this update.