### PR TITLE
(MODULES-5004) Support for "managed disks" 4/6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'azure', '~> 0.7.0'
 
-gem 'azure_mgmt_storage', '~> 0.3.0'
-gem 'azure_mgmt_compute', '~> 0.3.0'
-gem 'azure_mgmt_resources', '~> 0.3.0'
-gem 'azure_mgmt_network', '~> 0.3.0'
+gem 'azure_mgmt_storage', '~> 0.10.0'
+gem 'azure_mgmt_compute', '~> 0.10.0'
+gem 'azure_mgmt_resources', '~> 0.10.0'
+gem 'azure_mgmt_network', '~> 0.10.0'
 
 gem 'hocon'
 gem 'retries'

--- a/README.md
+++ b/README.md
@@ -327,6 +327,22 @@ The switch which behaves differenly depending what was activated:
 * Boot diagnostics - Configures the VM `diagnosticsProfile` setting to write out boot diagnostics .  Enabled manually via the portal if required.  Since boot diagnostics only apply at boot time, their most useful for interactive debugging when a VM is having a problems booting.  If required, boot diagnostics can be enabled through the Azure portal.
 * Guest diagnostics - Configures an extension to capture live diagnostic output.  This needs to be _different_ depending on the selected guest OS and is enabled by supplying the appropriate data to the `extensions` parameter.
 
+#### Managed Disks
+Azure's _managed disks_ feature removes the requirement to associate a storage account with each Azure VM, removing one of the fundamental limitations of the platform.  To use managed disks with `azure_vm`, set the `manged_disks` parameter to true:
+
+```puppet
+azure_vm { 'managed-disks-example':
+  ensure        => present,
+  location      => 'centralus',
+  image         => 'Canonical:UbuntuServer:16.10:latest',
+  user          => 'azureuser',
+  password      => 'Password_!',
+  managed_disks => true,
+}
+```
+
+Note that when using _managed disks_ its not possible to set _vhd_ options any more as the feature takes care of these for you.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppetlabs/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 
@@ -86,10 +86,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     gem install retries --no-ri --no-rdoc
     gem install azure --version="~>0.7.0" --no-ri --no-rdoc
-    gem install azure_mgmt_compute --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_storage --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_resources --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_network --version="~>0.3.0" --no-ri --no-rdoc
+    gem install azure_mgmt_compute --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_storage --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_resources --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_network --version="~>0.10.0" --no-ri --no-rdoc
     gem install hocon --version="~>1.1.2" --no-ri --no-rdoc
     ```
 
@@ -98,10 +98,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ azure_vm { 'ssd-example':
 
 To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
 
+#### Boot/guest diagnostics
+The Azure portal provides switches to enable _boot_diagnostics_ and _guest diagnostics_.  Both of which require access to a storage account to dump the diagnostic data.
+
+The switch which behaves differenly depending what was activated:
+* Boot diagnostics - Configures the VM `diagnosticsProfile` setting to write out boot diagnostics .  Enabled manually via the portal if required.  Since boot diagnostics only apply at boot time, their most useful for interactive debugging when a VM is having a problems booting.  If required, boot diagnostics can be enabled through the Azure portal.
+* Guest diagnostics - Configures an extension to capture live diagnostic output.  This needs to be _different_ depending on the selected guest OS and is enabled by supplying the appropriate data to the `extensions` parameter.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -300,6 +300,26 @@ azure_vm { 'sample':
 }
 ```
 
+#### Premium Storage
+
+Azure supports _premium_ SSD backed VMs for enhanced performance of production class environments.  SSD storage can be selected at the time of VM creation like this (`Premium_LRS` is the Azure API's internal representation):
+
+```puppet
+azure_vm { 'ssd-example':
+  ensure               => present,
+  location             => 'centralus',
+  image                => 'Canonical:UbuntuServer:16.10:latest',
+  user                 => 'azureuser',
+  password             => 'Password_!',
+  size                 => 'Standard_DS1_v2',
+  resource_group       => 'puppetvms',
+  storage_account_type => 'Premium_LRS',
+}
+
+```
+
+To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/lib/puppet/provider/azure_vm/azure_arm.rb
+++ b/lib/puppet/provider/azure_vm/azure_arm.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
 
   read_only(:image, :resource_group, :location, :size, :user, :os_disk_name,
             :os_disk_caching, :os_disk_create_option, :os_disk_vhd_container_name,
-            :os_disk_vhd_name, :network_interface_name, :plan)
+            :os_disk_vhd_name, :network_interface_name, :plan, :managed_disks)
 
   def self.instances
     begin
@@ -74,6 +74,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       }
       plan['promotion_code'] = machine.plan.promotion_code if machine.plan.promotion_code
     end
+    managed_disks = machine.storage_profile.os_disk.managed_disk != nil
 
     {
       name: machine.name,
@@ -92,6 +93,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       plan: plan,
       extensions: extensions,
       data_disks: data_disks,
+      managed_disks: managed_disks,
       object: machine,
     }
   end
@@ -140,6 +142,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       private_ip_allocation_method: resource[:private_ip_allocation_method],
       data_disks: resource[:data_disks],
       plan: resource[:plan],
+      managed_disks: resource[:managed_disks],
       # provider defaults recreate the defaults from the Azure Portal
       storage_account: default_based_on_resource_group(resource[:storage_account]),
       os_disk_name: default_to_name(resource[:os_disk_name]),

--- a/lib/puppet_x/puppetlabs/azure/property/boolean.rb
+++ b/lib/puppet_x/puppetlabs/azure/property/boolean.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module PuppetLabs
+    module Azure
+      module Property
+        class Boolean < Puppet::Property
+          validate do |value|
+            fail "#{self.name.to_s} should be a Boolean" unless !!value == value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -41,6 +41,7 @@ describe 'azure_vm', :type => :type do
       :extensions,
       :data_disks,
       :plan,
+      :managed_disks,
     ]
   end
 


### PR DESCRIPTION
Support azure's managed disks feature with a new parameter, `managed_disks`.  When selected, we will no longer specify VHD options or create a storage account since Azure now does all this for us.  Access to the ruby model classes supporting this feature is required to enable this (https://github.com/puppetlabs/puppetlabs-azure/pull/143)