### PR TITLE
(MODULES-5059) cross-resourcegroup networking 9/6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'azure', '~> 0.7.0'
 
-gem 'azure_mgmt_storage', '~> 0.3.0'
-gem 'azure_mgmt_compute', '~> 0.3.0'
-gem 'azure_mgmt_resources', '~> 0.3.0'
-gem 'azure_mgmt_network', '~> 0.3.0'
+gem 'azure_mgmt_storage', '~> 0.10.0'
+gem 'azure_mgmt_compute', '~> 0.10.0'
+gem 'azure_mgmt_resources', '~> 0.10.0'
+gem 'azure_mgmt_network', '~> 0.10.0'
 
 gem 'hocon'
 gem 'retries'

--- a/README.md
+++ b/README.md
@@ -327,6 +327,22 @@ The switch which behaves differenly depending what was activated:
 * Boot diagnostics - Configures the VM `diagnosticsProfile` setting to write out boot diagnostics .  Enabled manually via the portal if required.  Since boot diagnostics only apply at boot time, their most useful for interactive debugging when a VM is having a problems booting.  If required, boot diagnostics can be enabled through the Azure portal.
 * Guest diagnostics - Configures an extension to capture live diagnostic output.  This needs to be _different_ depending on the selected guest OS and is enabled by supplying the appropriate data to the `extensions` parameter.
 
+#### Managed Disks
+Azure's _managed disks_ feature removes the requirement to associate a storage account with each Azure VM, removing one of the fundamental limitations of the platform.  To use managed disks with `azure_vm`, set the `manged_disks` parameter to true:
+
+```puppet
+azure_vm { 'managed-disks-example':
+  ensure        => present,
+  location      => 'centralus',
+  image         => 'Canonical:UbuntuServer:16.10:latest',
+  user          => 'azureuser',
+  password      => 'Password_!',
+  managed_disks => true,
+}
+```
+
+Note that when using _managed disks_ its not possible to set _vhd_ options any more as the feature takes care of these for you.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ azure_vm { 'sample':
   private_ip_allocation_method  => 'Dynamic',
   network_interface_name        => 'nicspec01',
   network_security_group_name   => 'My-Network-Security-Group',
+  tags                          => { 'department' => 'devops', 'foo' => 'bar'},
   extensions                    => {
     'CustomScriptForLinux' => {
        'auto_upgrade_minor_version' => false,
@@ -777,6 +778,15 @@ plan => {
 },
 ```
 
+##### `tags`
+A hash of tags to label with.
+
+Example:
+
+```puppet
+tags => {'department' => 'devops', 'foo' => 'bar'}
+```
+
 ##### `extensions`
 
 The extension to configure on the VM. Azure VM Extensions implement behaviors or features that either help other programs work on Azure VMs. You can optionally configure this parameter to include an extension.
@@ -870,6 +880,15 @@ The type of storage account. This indicates the performance level and replicatio
 
 The kind of storage account. This indicates whether the storage account is general `Storage` or `BlobStorage`. Defaults to `Storage`.
 
+##### `tags`
+A hash of tags to label with.
+
+Example:
+
+```puppet
+tags => {'department' => 'devops', 'foo' => 'bar'}
+```
+
 #### Type: azure_resource_group
 
 ##### `ensure`
@@ -883,6 +902,15 @@ Specifies the basic state of the resource group. Valid values are 'present' and 
 ##### `location`
 
 *Required* The location where the resource group will be created. Details of available values can be found on the [Azure regions documentation](http://azure.microsoft.com/en-gb/regions/).
+
+##### `tags`
+A hash of tags to label with.
+
+Example:
+
+```puppet
+tags => {'department' => 'devops', 'foo' => 'bar'}
+```
 
 #### Type: azure_resource_template
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppetlabs/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 
@@ -86,10 +86,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     gem install retries --no-ri --no-rdoc
     gem install azure --version="~>0.7.0" --no-ri --no-rdoc
-    gem install azure_mgmt_compute --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_storage --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_resources --version="~>0.3.0" --no-ri --no-rdoc
-    gem install azure_mgmt_network --version="~>0.3.0" --no-ri --no-rdoc
+    gem install azure_mgmt_compute --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_storage --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_resources --version="~>0.10.0" --no-ri --no-rdoc
+    gem install azure_mgmt_network --version="~>0.10.0" --no-ri --no-rdoc
     gem install hocon --version="~>1.1.2" --no-ri --no-rdoc
     ```
 
@@ -98,10 +98,10 @@ To use the Resource Manager API instead, you need a service principal on the Act
     ```
     /opt/puppet/bin/gem install retries --no-ri --no-rdoc
     /opt/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.3.0' --no-ri --no-rdoc
-    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.3.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
+    /opt/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
     /opt/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
     ```
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ azure_vm { 'sample':
   ip_configuration_name         => 'ip_config_test01',
   private_ip_allocation_method  => 'Dynamic',
   network_interface_name        => 'nicspec01',
+  network_security_group_name   => 'My-Network-Security-Group',
   extensions                    => {
     'CustomScriptForLinux' => {
        'auto_upgrade_minor_version' => false,

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ azure_vm { 'ssd-example':
 
 To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
 
+#### Boot/guest diagnostics
+The Azure portal provides switches to enable _boot_diagnostics_ and _guest diagnostics_.  Both of which require access to a storage account to dump the diagnostic data.
+
+The switch which behaves differenly depending what was activated:
+* Boot diagnostics - Configures the VM `diagnosticsProfile` setting to write out boot diagnostics .  Enabled manually via the portal if required.  Since boot diagnostics only apply at boot time, their most useful for interactive debugging when a VM is having a problems booting.  If required, boot diagnostics can be enabled through the Azure portal.
+* Guest diagnostics - Configures an extension to capture live diagnostic output.  This needs to be _different_ depending on the selected guest OS and is enabled by supplying the appropriate data to the `extensions` parameter.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -300,6 +300,26 @@ azure_vm { 'sample':
 }
 ```
 
+#### Premium Storage
+
+Azure supports _premium_ SSD backed VMs for enhanced performance of production class environments.  SSD storage can be selected at the time of VM creation like this (`Premium_LRS` is the Azure API's internal representation):
+
+```puppet
+azure_vm { 'ssd-example':
+  ensure               => present,
+  location             => 'centralus',
+  image                => 'Canonical:UbuntuServer:16.10:latest',
+  user                 => 'azureuser',
+  password             => 'Password_!',
+  size                 => 'Standard_DS1_v2',
+  resource_group       => 'puppetvms',
+  storage_account_type => 'Premium_LRS',
+}
+
+```
+
+To successfully enable `Premium_LRS`, you **must** select a premium-capable VM size such as `Standard_DS1_v2`.  Regular HDD backed VMs can be created by using `Standard_LRS`.
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,27 @@ azure_vm { 'managed-disks-example':
 
 Note that when using _managed disks_ its not possible to set _vhd_ options any more as the feature takes care of these for you.
 
+#### Connecting to networks
+By default, all network objects created while provisioning an `azure_vm` will be created in the resource group you created the VM in.  This works fine in basic environments where everthing you want to talk to on non-public addresses is within the same resource group but if you need to _plug in_ to a network in another resource group, you will need to specify these during VM creation to avoid creating your VM in a miniture DMZ where it can't reach any other networks.
+
+To allow this functionality, `virtual_network_name`, `subnet_name` and
+`network_security_group_name` all allow the slashes to lookup the requested object in other resource groups.  Note that `subnet_name` must also specify the virtual network if using this feature:
+
+```puppet
+azure_vm { 'web01':
+  ensure                      => present,
+  location                    => 'centralus',
+  image                       => 'canonical:ubuntuserver:14.04.2-LTS:latest',
+  user                        => 'azureuser',
+  password                    => 'Password_!',
+  size                        => 'Standard_A0',
+  resource_group              => 'webservers-rg',
+  virtual_network_name        => 'hq-rg/delivery-vn',
+  subnet_name 	              => "hq-rg/delivery-vn/web-sn",
+  network_security_group_name => "hq-rg/delivery-nsg",
+}
+```
+
 ### List and manage VMs
 
 In addition to describing new machines using the DSL, the module also supports listing and managing machines via `puppet resource`:

--- a/lib/puppet/provider/azure_resource_group/arm.rb
+++ b/lib/puppet/provider/azure_resource_group/arm.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:azure_resource_group).provide(:arm, :parent => PuppetX::Puppe
 
   mk_resource_methods
 
-  read_only(:location)
+  read_only(:location, :tags)
 
   def self.instances # rubocop:disable Metrics/AbcSize
     begin
@@ -17,6 +17,7 @@ Puppet::Type.type(:azure_resource_group).provide(:arm, :parent => PuppetX::Puppe
           name: rg.id.split('/')[4],
           ensure: :present,
           location: rg.location,
+          tags: rg.tags,
           object: rg,
         }
         Puppet.debug("Ignoring #{name} due to invalid or incomplete response from Azure") unless hash
@@ -40,6 +41,7 @@ Puppet::Type.type(:azure_resource_group).provide(:arm, :parent => PuppetX::Puppe
     create_resource_group({
       resource_group: resource[:name],
       location: resource[:location],
+      tags: resource[:tags],
     })
     @property_hash[:ensure] = :present
   end

--- a/lib/puppet/provider/azure_storage_account/arm.rb
+++ b/lib/puppet/provider/azure_storage_account/arm.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
 
   mk_resource_methods
 
-  read_only(:location, :resource_group, :account_kind, :account_type)
+  read_only(:location, :resource_group, :account_kind, :account_type, :tags)
 
   def self.instances # rubocop:disable Metrics/AbcSize
     begin
@@ -17,6 +17,7 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
           name: sa.name,
           ensure: :present,
           location: sa.location,
+          tags: sa.tags,
           account_type: sa.sku.name,
           account_kind: sa.kind,
           resource_group: sa.id.split('/')[4],
@@ -46,6 +47,7 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
       storage_account_type: resource[:account_type],
       storage_account_kind: resource[:account_kind],
       location: resource[:location],
+      tags: resource[:tags],
     })
     @property_hash[:ensure] = :present
   end

--- a/lib/puppet/provider/azure_vm/azure_arm.rb
+++ b/lib/puppet/provider/azure_vm/azure_arm.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
 
   read_only(:image, :resource_group, :location, :size, :user, :os_disk_name,
             :os_disk_caching, :os_disk_create_option, :os_disk_vhd_container_name,
-            :os_disk_vhd_name, :network_interface_name, :plan, :managed_disks)
+            :os_disk_vhd_name, :network_interface_name, :plan, :managed_disks, :tags)
 
   def self.instances
     begin
@@ -90,6 +90,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       image: build_image_from_reference(machine.storage_profile.image_reference),
       resource_group: machine.id.split('/')[4].downcase,
       location: machine.location,
+      tags: machine.tags,
       size: machine.hardware_profile.vm_size,
       user: machine.os_profile.admin_username,
       os_disk_name: machine.storage_profile.os_disk.name,
@@ -151,6 +152,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       data_disks: resource[:data_disks],
       plan: resource[:plan],
       managed_disks: resource[:managed_disks],
+      tags: resource[:tags],
       # provider defaults recreate the defaults from the Azure Portal
       storage_account: default_based_on_resource_group(resource[:storage_account]),
       os_disk_name: default_to_name(resource[:os_disk_name]),

--- a/lib/puppet/provider/azure_vm/azure_arm.rb
+++ b/lib/puppet/provider/azure_vm/azure_arm.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
 
   read_only(:image, :resource_group, :location, :size, :user, :os_disk_name,
             :os_disk_caching, :os_disk_create_option, :os_disk_vhd_container_name,
-            :os_disk_vhd_name, :network_interface_name, :plan)
+            :os_disk_vhd_name, :network_interface_name, :plan, :managed_disks)
 
   def self.instances
     begin
@@ -74,6 +74,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       }
       plan['promotion_code'] = machine.plan.promotion_code if machine.plan.promotion_code
     end
+    managed_disks = machine.storage_profile.os_disk.managed_disk != nil
 
     {
       name: machine.name,
@@ -92,6 +93,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       plan: plan,
       extensions: extensions,
       data_disks: data_disks,
+      managed_disks: managed_disks,
       object: machine,
     }
   end
@@ -140,6 +142,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       private_ip_allocation_method: resource[:private_ip_allocation_method],
       data_disks: resource[:data_disks],
       plan: resource[:plan],
+      managed_disks: resource[:managed_disks],
       # provider defaults recreate the defaults from the Azure Portal
       storage_account: default_based_on_resource_group(resource[:storage_account]),
       os_disk_name: default_to_name(resource[:os_disk_name]),

--- a/lib/puppet/provider/azure_vm/azure_arm.rb
+++ b/lib/puppet/provider/azure_vm/azure_arm.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
   end
 
   def self.build_image_from_reference(image_reference)
-    "#{image_reference.publisher}:#{image_reference.offer}:#{image_reference.sku}:#{image_reference.version}"
+    "#{image_reference.publisher}:#{image_reference.offer}:#{image_reference.sku}:#{image_reference.version}" unless image_reference == nil
   end
 
   # Pick selected fields from Azure API representation of a
@@ -92,10 +92,10 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       location: machine.location,
       tags: machine.tags,
       size: machine.hardware_profile.vm_size,
-      user: machine.os_profile.admin_username,
-      os_disk_name: machine.storage_profile.os_disk.name,
-      os_disk_caching: machine.storage_profile.os_disk.caching,
-      os_disk_create_option: machine.storage_profile.os_disk.create_option,
+      user: (machine.os_profile.admin_username if machine.os_profile),
+      os_disk_name: (machine.storage_profile.os_disk.name if machine.storage_profile.os_disk),
+      os_disk_caching: (machine.storage_profile.os_disk.caching if machine.storage_profile.os_disk),
+      os_disk_create_option: (machine.storage_profile.os_disk.create_option if machine.storage_profile.os_disk),
       os_disk_vhd_container_name: vhd_container_name,
       os_disk_vhd_name: vhd_name,
       network_interface_name: network_interface_name,

--- a/lib/puppet/provider/azure_vm/azure_arm.rb
+++ b/lib/puppet/provider/azure_vm/azure_arm.rb
@@ -28,6 +28,14 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
     "#{image_reference.publisher}:#{image_reference.offer}:#{image_reference.sku}:#{image_reference.version}"
   end
 
+  # Pick selected fields from Azure API representation of a
+  # vm to build a hash suitable to represent the resource in
+  # puppet.  Azure uses several discrete components, read by
+  # separate client classes to represent items such as
+  # network and storage.  As such, they are not directly
+  # walkable from a machine instance so are absent from the
+  # puppet representation we return, although they may be
+  # set with puppet at the time of VM creation if destired
   def self.machine_to_hash(machine) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     stopped = machine.instance_view.statuses.find { |s| s.code =~ /PowerState\/stopped/ }.nil?
     ensure_value = stopped ? :running : :stopped
@@ -153,6 +161,7 @@ Puppet::Type.type(:azure_vm).provide(:azure_arm, :parent => PuppetX::Puppetlabs:
       virtual_network_name: default_to_resource_group(resource[:virtual_network_name]),
       ip_configuration_name: default_to_name(resource[:ip_configuration_name]),
       network_interface_name: default_based_on_name(resource[:network_interface_name]),
+      network_security_group_name: default_based_on_name(resource[:network_security_group_name]),
     })
 
     self.extensions = resource[:extensions] if resource[:extensions]

--- a/lib/puppet/type/azure_resource_group.rb
+++ b/lib/puppet/type/azure_resource_group.rb
@@ -3,6 +3,8 @@ require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/azure/property/read_only'
 require_relative '../../puppet_x/puppetlabs/azure/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/azure/property/string'
+require_relative '../../puppet_x/puppetlabs/azure/property/hash'
+
 
 Puppet::Type.newtype(:azure_resource_group) do
   @doc = 'Type representing a resource group in Microsoft Azure.'
@@ -43,5 +45,10 @@ Puppet::Type.newtype(:azure_resource_group) do
       super value
       fail 'the location must not be empty' if value.empty?
     end
+  end
+
+  newproperty(:tags, :parent => PuppetX::PuppetLabs::Azure::Property::Hash) do
+    desc 'The tags for the group'
+    defaultto {}
   end
 end

--- a/lib/puppet/type/azure_storage_account.rb
+++ b/lib/puppet/type/azure_storage_account.rb
@@ -3,6 +3,7 @@ require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/azure/property/read_only'
 require_relative '../../puppet_x/puppetlabs/azure/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/azure/property/string'
+require_relative '../../puppet_x/puppetlabs/azure/property/hash'
 
 Puppet::Type.newtype(:azure_storage_account) do
   @doc = 'Type representing a storage account in Microsoft Azure.'
@@ -63,6 +64,11 @@ Puppet::Type.newtype(:azure_storage_account) do
       super value
       fail 'the location must not be empty' if value.empty?
     end
+  end
+
+  newproperty(:tags, :parent => PuppetX::PuppetLabs::Azure::Property::Hash) do
+    desc 'The tags for the instance'
+    defaultto {}
   end
 
   autorequire(:azure_resource_group) do

--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -323,6 +323,13 @@ The keys that should be in the hash are:
     defaultto false
   end
 
+  newproperty(:network_security_group_name, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
+    desc 'The network security group name'
+    def insync?(is)
+      true
+    end
+  end
+
   autorequire(:azure_resource_group) do
     self[:resource_group]
   end

--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -330,6 +330,11 @@ The keys that should be in the hash are:
     end
   end
 
+  newproperty(:tags, :parent => PuppetX::PuppetLabs::Azure::Property::Hash) do
+    desc 'The tags for the instance'
+    defaultto {}
+  end
+
   autorequire(:azure_resource_group) do
     self[:resource_group]
   end

--- a/lib/puppet_x/puppetlabs/azure/config.rb
+++ b/lib/puppet_x/puppetlabs/azure/config.rb
@@ -1,4 +1,4 @@
-require 'hocon'
+require 'hocon' if Puppet.features.azure_hocon?
 require 'puppet'
 
 module PuppetX

--- a/lib/puppet_x/puppetlabs/azure/property/boolean.rb
+++ b/lib/puppet_x/puppetlabs/azure/property/boolean.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module PuppetLabs
+    module Azure
+      module Property
+        class Boolean < Puppet::Property
+          validate do |value|
+            fail "#{self.name.to_s} should be a Boolean" unless !!value == value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/azure/provider_arm.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_arm.rb
@@ -58,12 +58,14 @@ module PuppetX
             register_providers
             create_resource_group(args)
             params = build_params(args)
+
             if ! args[:managed_disks]
               create_storage_account({
                 storage_account: args[:storage_account],
                 resource_group: args[:resource_group],
                 storage_account_type: args[:storage_account_type],
                 location: args[:location],
+                tags: args[:tags],
               })
             end
             ProviderArm.compute_client.virtual_machines.create_or_update(args[:resource_group], args[:name], params)
@@ -394,7 +396,7 @@ module PuppetX
 
         def build_template_deployment(args)
           build(::Azure::ARM::Resources::Models::Deployment, {
-            properties: build_template_deployment_properties(args)
+            properties: build_template_deployment_properties(args),
           })
         end
 
@@ -418,6 +420,7 @@ module PuppetX
         def build_storage_account_create_parameters(args)
           build(::Azure::ARM::Storage::Models::StorageAccountCreateParameters, {
             location: args[:location],
+            tags: args[:tags],
             kind: Object.const_get("::Azure::ARM::Storage::Models::Kind::#{args[:storage_account_kind] || :Storage}"),
             sku: build(::Azure::ARM::Storage::Models::Sku, {
               name: args[:storage_account_type],
@@ -494,7 +497,8 @@ module PuppetX
             public_ipallocation_method: args[:public_ip_allocation_method],
             dns_settings: build(::Azure::ARM::Network::Models::PublicIPAddressDnsSettings, {
               domain_name_label: args[:dns_domain_name],
-            })
+            }),
+            tags: args[:tags],
           })
         end
 
@@ -526,6 +530,7 @@ module PuppetX
         def build_network_security_group_params(args)
           build(::Azure::ARM::Network::Models::NetworkSecurityGroup, {
             location: args[:location],
+            tags: args[:tags],
           })
         end
 
@@ -548,6 +553,7 @@ module PuppetX
               public_ipaddress: public_ipaddress,
             })],
             network_security_group: network_security_group,
+            tags: args[:tags],
           })
         end
 
@@ -602,6 +608,7 @@ module PuppetX
             network_profile: properties.network_profile,
             plan: build_plan(args),
             location: args[:location],
+            tags: args[:tags],
           })
         end
       end

--- a/lib/puppet_x/puppetlabs/azure/provider_arm.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_arm.rb
@@ -3,11 +3,11 @@ require 'puppet_x/puppetlabs/azure/config'
 require 'puppet_x/puppetlabs/azure/not_finished'
 require 'puppet_x/puppetlabs/azure/provider_base'
 
-require 'azure_mgmt_compute'
-require 'azure_mgmt_resources'
-require 'azure_mgmt_storage'
-require 'azure_mgmt_network'
-require 'ms_rest_azure'
+require 'azure_mgmt_compute' if Puppet.features.azure?
+require 'azure_mgmt_resources' if Puppet.features.azure?
+require 'azure_mgmt_storage' if Puppet.features.azure?
+require 'azure_mgmt_network' if Puppet.features.azure?
+require 'ms_rest_azure' if Puppet.features.azure?
 
 module PuppetX
   module Puppetlabs

--- a/spec/unit/type/azure_resource_group_spec.rb
+++ b/spec/unit/type/azure_resource_group_spec.rb
@@ -13,6 +13,7 @@ describe 'azure_resource_group', :type => :type do
     [
       :ensure,
       :location,
+      :tags,
     ]
   end
 

--- a/spec/unit/type/azure_storage_account_spec.rb
+++ b/spec/unit/type/azure_storage_account_spec.rb
@@ -15,6 +15,7 @@ describe 'azure_storage_account', :type => :type do
       :location,
       :account_type,
       :account_kind,
+      :tags,
       :resource_group,
     ]
   end

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -42,6 +42,7 @@ describe 'azure_vm', :type => :type do
       :data_disks,
       :plan,
       :managed_disks,
+      :network_security_group_name,
     ]
   end
 

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -43,6 +43,7 @@ describe 'azure_vm', :type => :type do
       :plan,
       :managed_disks,
       :network_security_group_name,
+      :tags,
     ]
   end
 

--- a/spec/unit/type/azure_vm_spec.rb
+++ b/spec/unit/type/azure_vm_spec.rb
@@ -41,6 +41,7 @@ describe 'azure_vm', :type => :type do
       :extensions,
       :data_disks,
       :plan,
+      :managed_disks,
     ]
   end
 


### PR DESCRIPTION
Parse network names with slashes to allow looking up networking objects from other resource groups.  This allows us to _plug in_ to virtual networks, subnets and network security groups created in other resource groups