### PR TITLE
(MODULES-4466) improve visibility of ruby gem versions required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ as code.
 
 ### Requirements
 
-*   [Azure gem](https://rubygems.org/gems/azure) 0.7.0 or greater.
+*   Ruby Gems as follows (see [Installing the Azure module](#installing-the-azure-module), below).
+    *   [azure](https://rubygems.org/gems/azure) 0.7.x
+    *   [azure_mgmt_storage](https://rubygems.org/gems/azure_mgmt_storage) 0.3.x
+    *   [azure_mgmt_compute](https://rubygems.org/gems/azure_mgmt_compute) 0.3.x
+    *   [azure_mgmt_resources](https://rubygems.org/gems/azure_mgmt_resources) 0.3.x
+    *   [azure_mgmt_network](https://rubygems.org/gems/azure_mgmt_network) 0.3.x
+    *   [hocon](https://rubygems.org/gems/hocon) 1.1.x
 *   Azure credentials (as detailed below).
 
 #### Get Azure credentials


### PR DESCRIPTION
This calls out the list of gems required, and their version requirements, so it's hard to miss in the README. Given the error you get if you installer a version of some of these gems that's newer than May 2016 is so [obtuse](https://tickets.puppetlabs.com/browse/MODULES-5477) I think it's important this is called out more visibly in the readme. 