### PR TITLE
Add sku, tier, and https-only storage account params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Supported Version 1.2.1
+This release adds support for blob, cold, and https-only storage accounts
+
 ## Supported Version 1.2.0
 ### Added
  - Support for Azure's managed disks feature removes the requirement to associate a storage account with each Azure VM, removing one of the fundamental limitations of the platform.

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'azure', '~> 0.7.0'
 
-gem 'azure_mgmt_storage', '~> 0.11.0'
-gem 'azure_mgmt_compute', '~> 0.11.0'
-gem 'azure_mgmt_resources', '~> 0.11.0'
-gem 'azure_mgmt_network', '~> 0.11.0'
+gem 'azure_mgmt_storage', '~> 0.14.0'
+gem 'azure_mgmt_compute', '~> 0.14.0'
+gem 'azure_mgmt_resources', '~> 0.14.0'
+gem 'azure_mgmt_network', '~> 0.14.0'
 
 gem 'hocon'
 gem 'retries'

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Install the required gems with this command on `puppet-agent` 1.2 (included in P
 ``` shell
 /opt/puppetlabs/puppet/bin/gem install retries --no-ri --no-rdoc
 /opt/puppetlabs/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-/opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
+/opt/puppetlabs/puppet/bin/gem install azure_mgmt_compute --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppetlabs/puppet/bin/gem install azure_mgmt_storage --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppetlabs/puppet/bin/gem install azure_mgmt_resources --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppetlabs/puppet/bin/gem install azure_mgmt_network --version='~>0.14.0' --no-ri --no-rdoc
 /opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
 ```
 
@@ -88,10 +88,10 @@ When installing on Windows, launch `Start Command Prompt with Puppet` and enter:
 ``` shell
 gem install retries --no-ri --no-rdoc
 gem install azure --version="~>0.7.0" --no-ri --no-rdoc
-gem install azure_mgmt_compute --version="~>0.10.0" --no-ri --no-rdoc
-gem install azure_mgmt_storage --version="~>0.10.0" --no-ri --no-rdoc
-gem install azure_mgmt_resources --version="~>0.10.0" --no-ri --no-rdoc
-gem install azure_mgmt_network --version="~>0.10.0" --no-ri --no-rdoc
+gem install azure_mgmt_compute --version="~>0.14.0" --no-ri --no-rdoc
+gem install azure_mgmt_storage --version="~>0.14.0" --no-ri --no-rdoc
+gem install azure_mgmt_resources --version="~>0.14.0" --no-ri --no-rdoc
+gem install azure_mgmt_network --version="~>0.14.0" --no-ri --no-rdoc
 gem install hocon --version="~>1.1.2" --no-ri --no-rdoc
 ```
 
@@ -100,10 +100,10 @@ On versions of `puppet agent` older than 1.2 (Puppet Enterprise 2015.2.0), use t
 ``` shell
 /opt/puppet/bin/gem install retries --no-ri --no-rdoc
 /opt/puppet/bin/gem install azure --version='~>0.7.0' --no-ri --no-rdoc
-/opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.10.0' --no-ri --no-rdoc
-/opt/puppet/bin/gem install azure_mgmt_network --version='~>0.10.0' --no-ri --no-rdoc
+/opt/puppet/bin/gem install azure_mgmt_compute --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppet/bin/gem install azure_mgmt_storage --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppet/bin/gem install azure_mgmt_resources --version='~>0.14.0' --no-ri --no-rdoc
+/opt/puppet/bin/gem install azure_mgmt_network --version='~>0.14.0' --no-ri --no-rdoc
 /opt/puppet/bin/gem install hocon --version='~>1.1.2' --no-ri --no-rdoc
 ```
 

--- a/lib/puppet/provider/azure_storage_account/arm.rb
+++ b/lib/puppet/provider/azure_storage_account/arm.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
 
   mk_resource_methods
 
-  read_only(:location, :resource_group, :account_kind, :account_type, :tags)
+  read_only(:location, :resource_group, :account_kind, :account_type, :sku_name, :sku_tier, :access_tier, :https_traffic_only, :tags)
 
   def self.instances # rubocop:disable Metrics/AbcSize
     begin
@@ -19,7 +19,11 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
           location: sa.location,
           tags: sa.tags,
           account_type: sa.sku.name,
+          sku_name: sa.sku.name,
+          sku_tier: sa.sku.tier,
           account_kind: sa.kind,
+          access_tier: sa.access_tier,
+          https_traffic_only: sa.enable_https_traffic_only,
           resource_group: sa.id.split('/')[4],
           object: sa,
         }
@@ -44,11 +48,14 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
     # storage_account_type and storage_account_kind are enumerated and puppet
     # will automatically convert them to symbols - we need them as strings or we
     # will get an error during serialization
+    Puppet.info("Creating storage_account #{resource[:name]} in resource group #{resource[:resource_group]}")
     create_storage_account({
-      storage_account: resource[:name],
+      name: resource[:name],
       resource_group: resource[:resource_group],
-      storage_account_type: resource[:account_type].to_s,
+      sku_name: resource[:sku_name].to_s || :resource[:account_type].to_s,
       storage_account_kind: resource[:account_kind].to_s,
+      access_tier: resource[:access_tier].to_s,
+      enable_https_traffic_only: resource[:https_traffic_only],
       location: resource[:location],
       tags: resource[:tags],
     })
@@ -56,7 +63,11 @@ Puppet::Type.type(:azure_storage_account).provide(:arm, :parent => PuppetX::Pupp
   end
 
   def destroy
-    delete_storage_account(storage_account)
+    Puppet.info("Deleting storage_account #{resource[:name]} from resource group #{resource[:resource_group]}")
+    delete_storage_account({
+      name: resource[:name],
+      resource_group: resource[:resource_group],
+    })
     @property_hash[:ensure] = :absent
   end
 end

--- a/lib/puppet/type/azure_storage_account.rb
+++ b/lib/puppet/type/azure_storage_account.rb
@@ -4,6 +4,7 @@ require_relative '../../puppet_x/puppetlabs/azure/property/read_only'
 require_relative '../../puppet_x/puppetlabs/azure/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/azure/property/string'
 require_relative '../../puppet_x/puppetlabs/azure/property/hash'
+require_relative '../../puppet_x/puppetlabs/azure/property/boolean'
 
 Puppet::Type.newtype(:azure_storage_account) do
   @doc = 'Type representing a storage account in Microsoft Azure.'
@@ -29,6 +30,7 @@ Puppet::Type.newtype(:azure_storage_account) do
       super value
       fail 'the name must not be empty' if value.empty?
       fail("The name must be between 3 and 24 characters in length") if value.size > 24 or value.size < 3
+      fail("The name can contain only alphanumeric characters") unless value =~ %r{^[\w]+$}
     end
     def insync?(is)
       is.casecmp(should).zero?
@@ -47,6 +49,10 @@ Puppet::Type.newtype(:azure_storage_account) do
   end
 
   newproperty(:account_type, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
+    desc 'DEPRECATED name of the storage account performance & replication SKU (replaced by sku_name)'
+  end
+
+  newproperty(:sku_name, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
     desc 'The name of the storage account performance & replication SKU (account type)'
     newvalues('Standard_LRS', 'Standard_ZRS', 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS')
     defaultto 'Standard_GRS'
@@ -56,6 +62,16 @@ Puppet::Type.newtype(:azure_storage_account) do
     desc 'The kind of storage account'
     newvalues('Storage', 'BlobStorage')
     defaultto 'Storage'
+  end
+
+  newproperty(:access_tier, :parent => PuppetX::PuppetLabs::Azure::Property::String) do
+    desc 'The access tier for Blob storage accounts'
+    newvalues('Hot', 'Cool')
+  end
+
+  newproperty(:https_traffic_only, :parent => PuppetX::PuppetLabs::Azure::Property::Boolean) do
+    desc 'Allows https traffic only to storage service if set'
+    defaultto false
   end
 
   newproperty(:location, :parent => PuppetX::PuppetLabs::Azure::Property::String) do

--- a/spec/acceptance/storage_account_spec.rb
+++ b/spec/acceptance/storage_account_spec.rb
@@ -13,7 +13,7 @@ describe 'azure_storage_account when creating a storage account' do
       optional: {
         location: CHEAPEST_ARM_LOCATION,
         resource_group: SPEC_RESOURCE_GROUP,
-        account_type: 'Standard_GRS',
+        sku_name: 'Standard_GRS',
         account_kind: 'Storage',
       },
     }
@@ -33,7 +33,7 @@ describe 'azure_storage_account when creating a storage account' do
     include_context 'a puppet ARM resource run', 'azure_storage_account'
     puppet_resource_should_show('ensure', 'present')
     puppet_resource_should_show('location', CHEAPEST_ARM_LOCATION)
-    puppet_resource_should_show('account_type', 'Standard_GRS')
+    puppet_resource_should_show('sku_name', 'Standard_GRS')
     puppet_resource_should_show('account_kind', 'Storage')
     puppet_resource_should_show('resource_group', SPEC_RESOURCE_GROUP.downcase)
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -97,10 +97,10 @@ RSpec.configure do |c|
             [ 'git' ],
             [ 'hocon', 'retries' ],
             # Azure gems require pinning because they are still under heavy development and change their API frequently
-            [ 'azure_mgmt_compute', '--version=~> 0.11.0' ],
-            [ 'azure_mgmt_network', '--version=~> 0.11.0' ],
-            [ 'azure_mgmt_resources', '--version=~> 0.11.0' ],
-            [ 'azure_mgmt_storage', '--version=~> 0.11.0' ],
+            [ 'azure_mgmt_compute', '--version=~> 0.14.0' ],
+            [ 'azure_mgmt_network', '--version=~> 0.14.0' ],
+            [ 'azure_mgmt_resources', '--version=~> 0.14.0' ],
+            [ 'azure_mgmt_storage', '--version=~> 0.14.0' ],
             [ 'azure', '--version=~> 0.7.0' ],
           ]
 

--- a/spec/unit/type/azure_storage_account_spec.rb
+++ b/spec/unit/type/azure_storage_account_spec.rb
@@ -12,9 +12,12 @@ describe 'azure_storage_account', :type => :type do
   let :properties do
     [
       :ensure,
-      :location,
       :account_type,
+      :sku_name,
       :account_kind,
+      :access_tier,
+      :https_traffic_only,
+      :location,
       :tags,
       :resource_group,
     ]
@@ -47,7 +50,7 @@ describe 'azure_storage_account', :type => :type do
 
   [
     'location',
-    'account_type',
+    'sku_name',
     'account_kind',
     'resource_group',
   ].each do |property|
@@ -100,9 +103,41 @@ describe 'azure_storage_account', :type => :type do
       end
     end
 
+    context 'with account_type instead of sku_name' do
+      let :config do
+        result = default_config
+        result.delete(:sku_name)
+        result[:account_type] = 'Standard_GRS'
+        result
+      end
+
+      it 'should be invalid' do
+        expect { type_class.new(config) }.to_not raise_error
+      end
+    end
+
+    context 'with non-alpha characters in the name' do
+      let :config do
+        result = default_config
+        result[:name] = 'Junk! Entry%'
+        result
+      end
+
+      it 'should be invalid' do
+        expect { type_class.new(config) }.to raise_error(Puppet::ResourceError, /name can contain only alphanumeric characters/)
+      end
+    end
 
     it "should default ensure to present" do
       expect(storage_account[:ensure]).to eq(:present)
+    end
+
+    it "should default account_kind to Storage" do
+      expect(storage_account[:account_kind]).to eq(:Storage)
+    end
+
+    it "should default https_traffic_only to false" do
+      expect(storage_account[:https_traffic_only]).to be_falsey
     end
   end
 end


### PR DESCRIPTION
Catches invalid storage account names
Increases the number of problems caught
Provides a useful error message if operation fails
Deprecates account_type in favor of sku_name