### PR TITLE
Added deallocated state to help with cost control

### DIFF
--- a/lib/puppet/type/azure_vm.rb
+++ b/lib/puppet/type/azure_vm.rb
@@ -59,6 +59,7 @@ Puppet::Type.newtype(:azure_vm) do
         provider.create
       end
     end
+
     newvalue(:stopped) do
       if provider.exists?
         provider.stop unless provider.stopped?
@@ -67,6 +68,17 @@ Puppet::Type.newtype(:azure_vm) do
         provider.stop
       end
     end
+
+    newvalue(:deallocated) do
+      if provider.exists?
+        provider.deallocate unless provider.deallocated?
+      else
+        provider.create
+        provider.deallocate
+      end
+    end
+
+
     def change_to_s(current, desired)
       current = :running if current == :present
       desired = current if desired == :present and current != :absent

--- a/lib/puppet_x/puppetlabs/azure/provider_arm.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_arm.rb
@@ -122,6 +122,18 @@ module PuppetX
           end
         end
 
+        def deallocate_vm(machine)
+          begin
+            ProviderArm.compute_client.virtual_machines.deallocate(resource_group, machine.name)
+          rescue MsRestAzure::AzureOperationError => err
+            raise Puppet::Error, JSON.parse(err.message)['message']
+          rescue MsRest::DeserializationError => err
+            raise Puppet::Error, err.response_body
+          rescue MsRest::RestError => err
+            raise Puppet::Error, err.to_s
+          end
+        end
+
         def start_vm(machine)
           begin
             ProviderArm.compute_client.virtual_machines.start(resource_group, machine.name)

--- a/lib/puppet_x/puppetlabs/azure/provider_base.rb
+++ b/lib/puppet_x/puppetlabs/azure/provider_base.rb
@@ -49,10 +49,25 @@ module PuppetX
           !stopped?
         end
 
+        def stopped?
+         exists? && @property_hash[:ensure] == :stopped 
+        end
+
+
+	def deallocated?
+	  exists? && @property_hash[:ensure] == :deallocated	
+	end
+
         def stop
           Puppet.info("Stopping #{name}")
           stop_vm(machine)
           @property_hash[:ensure] = :stopped
+        end
+
+        def deallocate
+          Puppet.info("Deallocating #{name}")
+          deallocate_vm(machine)
+          @property_hash[:ensure] = :deallocated
         end
 
         def start

--- a/spec/unit/provider/azure_vm/azure_arm_spec.rb
+++ b/spec/unit/provider/azure_vm/azure_arm_spec.rb
@@ -45,7 +45,7 @@ describe provider_class do
     end
   end
 
-  [:exists?, :create, :destroy, :running?, :stopped?, :start, :stop].each do |method|
+  [:exists?, :create, :destroy, :running?, :stopped?, :start, :stop, :deallocate, :deallocated?].each do |method|
     it "should respond to the instance method #{method}" do
       expect(provider_class.new).to respond_to(method)
     end


### PR DESCRIPTION
The module (class azure_vm) as is was had no support for a deallocated ensure state.

As Azure continues to bill for vms in a stopped state I added the deallocated state.

All defaults remain the same, but manifest requesting and ensure state of deallocated will now work

test harness updated accordingly.